### PR TITLE
fix(marketplace/ghost): Safe placeholder

### DIFF
--- a/marketplace/ghost.json
+++ b/marketplace/ghost.json
@@ -36,7 +36,7 @@
     },
     {
       "name": "url",
-      "value": "https://ghost.zeabur.app"
+      "value": "https://your-domain.tld"
     }
   ]
 }


### PR DESCRIPTION
`ghost` actually picks the `url` environment variable; therefore, we should not set a value that is registerable to prevent the potential malicious attack.