### PR TITLE
chore: bump halo version to 2.6

### DIFF
--- a/marketplace/halo.json
+++ b/marketplace/halo.json
@@ -4,7 +4,7 @@
   "name": "Halo",
   "description": "Halo is a powerful and easy-to-use open source website building tool.",
   "icon": "https://avatars.githubusercontent.com/u/48195280?s=200&v=4",
-  "image": "halohub/halo:2.5",
+  "image": "halohub/halo:2.6",
   "command": null,
   "args": null,
   "port": 8090,


### PR DESCRIPTION
Bump Halo version to 2.6.

https://github.com/halo-dev/halo/releases/tag/v2.6.0