### PR TITLE
fix(marketplace): add mysql support to umami

### DIFF
--- a/marketplace/umami-mysql.json
+++ b/marketplace/umami-mysql.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "./schema.json",
+  "code": "umami-mysql",
+  "name": "Umami (MySQL)",
+  "description": "Umami is a simple, fast, privacy-focused alternative to Google Analytics.",
+  "icon": "https://svgur.com/i/sCX.svg",
+  "image": "ghcr.io/umami-software/umami:mysql-latest",
+  "command": null,
+  "args": null,
+  "port": 3000,
+  "network": "HTTP",
+  "variables": [
+    {
+      "name": "DATABASE_URL",
+      "value": "mysql://${MYSQL_USERNAME}:${MYSQL_PASSWORD}@${MYSQL_HOST}:${MYSQL_PORT}/umami"
+    },
+    {
+      "name": "DATABASE_TYPE",
+      "value": "mysql"
+    },
+    {
+      "name": "HASH_SALT",
+      "value": "${PASSWORD}"
+    }
+  ]
+}


### PR DESCRIPTION
## why
https://github.com/zeabur/zeabur/blob/main/marketplace/umami.json#L7
看起來原本 umami 是用 postgres 的 image，這會導致若用 mysql 為數據庫的話會 connect 不到
<img width="669" alt="截圖 2023-08-09 晚上9 34 45" src="https://github.com/zeabur/zeabur/assets/38397958/9b36adbe-899b-4a9c-8e6f-6567cea3d1e0">

## what
這邊新增 mysql 版本的 image

ref: https://github.com/umami-software/umami/pkgs/container/umami/114983885?tag=mysql-latest