### PR TITLE
fix: fix postgres environment variable

### DIFF
--- a/docs/pages/databases/postgresql.en-US.mdx
+++ b/docs/pages/databases/postgresql.en-US.mdx
@@ -30,15 +30,15 @@ After selecting PostgreSQL, Zeabur will automatically start deploying your Postg
 
 After you deploy the PostgreSQL service, Zeabur will automatically inject the relevant environment variables into other services.
 
-- `POSTGRESQL_HOST`
-- `POSTGRESQL_PORT`
-- `POSTGRESQL_USERNAME`
-- `POSTGRESQL_PASSWORD`
+- `POSTGRES_HOST`
+- `POSTGRES_PORT`
+- `POSTGRES_USERNAME`
+- `POSTGRES_PASSWORD`
 
 Sometimes, we can use the self-added `DATABASE_URL` to replace the above environment variables, for example:
 
 ```bash copy
-postgres://<POSTGRESQL_USERNAME>:<POSTGRESQL_PASSWORD>@<POSTGRESQL_HOST>:<POSTGRESQL_PORT>/<DATABASE_NAME>
+postgres://<POSTGRES_USERNAME>:<POSTGRES_PASSWORD>@<POSTGRES_HOST>:<POSTGRES_PORT>/<DATABASE_NAME>
 ```
 
 Here, `<DATABASE_NAME>` is the name of the database that you added yourself.
@@ -91,7 +91,7 @@ psql --version
 You can use [psql](https://www.postgresql.org/docs/current/app-psql.html) to connect to the PostgreSQL database deployed on Zeabur by simply entering the following command:
 
 ```bash copy
-psql -h <POSTGRESQL_HOST> -p <POSTGRESQL_PORT> -U <POSTGRESQL_USERNAME> -W
+psql -h <POSTGRES_HOST> -p <POSTGRES_PORT> -U <POSTGRES_USERNAME> -W
 ```
 
 ```sql copy

--- a/docs/pages/databases/postgresql.zh-CN.mdx
+++ b/docs/pages/databases/postgresql.zh-CN.mdx
@@ -29,15 +29,15 @@ Zeabur 提供了一键部署 PostgreSQL 服务的功能，让你可以快速地�
 
 当你部署 PostgreSQL 服务后，Zeabur 会自动帮你注入相关环境变量到其他的服务中。
 
-- `POSTGRESQL_HOST`
-- `POSTGRESQL_PORT`
-- `POSTGRESQL_USERNAME`
-- `POSTGRESQL_PASSWORD`
+- `POSTGRES_HOST`
+- `POSTGRES_PORT`
+- `POSTGRES_USERNAME`
+- `POSTGRES_PASSWORD`
 
 有时候我们可以用自行新增 `DATABASE_URL` 来取代上面的环境变量，例如：
 
 ```bash copy
-postgres://<POSTGRESQL_USERNAME>:<POSTGRESQL_PASSWORD>@<POSTGRESQL_HOST>:<POSTGRESQL_PORT>/<DATABASE_NAME>
+postgres://<POSTGRES_USERNAME>:<POSTGRES_PASSWORD>@<POSTGRES_HOST>:<POSTGRES_PORT>/<DATABASE_NAME>
 ```
 
 这里的 `<DATABASE_NAME>` 是你自行新增的数据库名称。
@@ -90,7 +90,7 @@ psql --version
 你可以使用 [psql](https://www.postgresql.org/docs/current/app-psql.html) 来连接到你部署在 Zeabur 的 PostgreSQL 数据库，只要输入以下指令：
 
 ```bash copy
-psql -h <POSTGRESQL_HOST> -p <POSTGRESQL_PORT> -U <POSTGRESQL_USERNAME> -W
+psql -h <POSTGRES_HOST> -p <POSTGRES_PORT> -U <POSTGRES_USERNAME> -W
 ```
 
 ```sql copy

--- a/docs/pages/databases/postgresql.zh-TW.mdx
+++ b/docs/pages/databases/postgresql.zh-TW.mdx
@@ -29,15 +29,15 @@ Zeabur 提供了一鍵部署 PostgreSQL 服務的功能，讓你可以快速地�
 
 當你部署 PostgreSQL 服務後，Zeabur 會自動幫你注入相關環境變數到其他的服務中。
 
-- `POSTGRESQL_HOST`
-- `POSTGRESQL_PORT`
-- `POSTGRESQL_USERNAME`
-- `POSTGRESQL_PASSWORD`
+- `POSTGRES_HOST`
+- `POSTGRES_PORT`
+- `POSTGRES_USERNAME`
+- `POSTGRES_PASSWORD`
 
 有時候我們可以用自行新增 `DATABASE_URL` 來取代上面的環境變數，例如：
 
 ```bash copy
-postgres://<POSTGRESQL_USERNAME>:<POSTGRESQL_PASSWORD>@<POSTGRESQL_HOST>:<POSTGRESQL_PORT>/<DATABASE_NAME>
+postgres://<POSTGRES_USERNAME>:<POSTGRES_PASSWORD>@<POSTGRES_HOST>:<POSTGRES_PORT>/<DATABASE_NAME>
 ```
 
 這裡的 `<DATABASE_NAME>` 是你自行新增的資料庫名稱。
@@ -90,7 +90,7 @@ psql --version
 你可以使用 [psql](https://www.postgresql.org/docs/current/app-psql.html) 來連接到你部署在 Zeabur 的 PostgreSQL 資料庫，只要輸入以下指令：
 
 ```bash copy
-psql -h <POSTGRESQL_HOST> -p <POSTGRESQL_PORT> -U <POSTGRESQL_USERNAME> -W
+psql -h <POSTGRES_HOST> -p <POSTGRES_PORT> -U <POSTGRES_USERNAME> -W
 ```
 
 ```sql copy


### PR DESCRIPTION
In the document variable's prefix is `POSTGRESQL_`, but in fact variable's prefix is `POSTGRES`:

<img width="812" alt="image" src="https://github.com/zeabur/zeabur/assets/50652358/41b6ff84-1e61-4352-9c58-385de50e9570">
