### PR TITLE
chore: bump halo version to 2.10

### DIFF
--- a/marketplace/halo.json
+++ b/marketplace/halo.json
@@ -4,7 +4,7 @@
   "name": "Halo",
   "description": "Halo is a powerful and easy-to-use open source website building tool.",
   "icon": "https://avatars.githubusercontent.com/u/48195280?s=200&v=4",
-  "image": "halohub/halo:2.9",
+  "image": "halohub/halo:2.10",
   "command": null,
   "args": null,
   "port": 8090,

--- a/prebuilts/halo.toml
+++ b/prebuilts/halo.toml
@@ -6,7 +6,7 @@ icon = "https://avatars.githubusercontent.com/u/48195280?s=200&v=4"
 description = "Halo is a powerful and easy-to-use open source website building tool."
 
 [source]
-image = "halohub/halo:2.9"
+image = "halohub/halo:2.10"
 
 [[ports]]
 id = "web"


### PR DESCRIPTION
Bump Halo version to 2.10

https://github.com/halo-dev/halo/releases/tag/v2.10.0