### PR TITLE
ZEA-1980: Prebuilt's Mongo Connection Command calls mongosh

### DIFF
--- a/prebuilts/mongodb.toml
+++ b/prebuilts/mongodb.toml
@@ -32,7 +32,7 @@ MONGO_CONNECTION_STRING_PORTFORWARDED = { default = "mongodb://${MONGO_USERNAME}
 [[instructions]]
 type = "TEXT"
 title = "Command to connect to your MongoDB"
-content = "mongo \"${MONGO_CONNECTION_STRING_PORTFORWARDED}\""
+content = "mongosh \"${MONGO_CONNECTION_STRING_PORTFORWARDED}\""
 showWhen = "PORT_FORWARDING"
 
 [[instructions]]


### PR DESCRIPTION
- ci: Check if prebuilt definition matches schema
- fix(prebuilts/mongodb): Use mongosh to connect to the database
