### PR TITLE
docs(builds/zh-CN): "zbpack" typo in URL

### DIFF
--- a/docs/pages/advanced/builds.zh-CN.mdx
+++ b/docs/pages/advanced/builds.zh-CN.mdx
@@ -8,7 +8,7 @@ ogImageSubtitle: Zeabur 内部构建用户服务的方式
 
 Zeabur 使用 [zbpack](https://github.com/zeabur/zbpack) 作为内部构建用户服务的工具，让用户可以在不需要理解复杂细节的情况下，一键部署基于任何语言和框架的服务。
 
-目前，[zbpack](https://github.com/zeabur/zbapck) 已经支持所有网页开发主流的程式语言，并对各个较热门的开发框架实现了进一步的识别及优化，同时也在不断为新出现的程式语言和框架推出更新：
+目前，[zbpack](https://github.com/zeabur/zbpack) 已经支持所有网页开发主流的程式语言，并对各个较热门的开发框架实现了进一步的识别及优化，同时也在不断为新出现的程式语言和框架推出更新：
 
 - Node.js
 - Python


### PR DESCRIPTION
Change zbapck to zbpack.
The second zbpack link in the document is mistyped as https://github.com/zeabur/zbapck, and should be the correct URL https://github.com/zeabur/zbpack aligned with the above.