### PR TITLE
feat(docs/rabbitmq.toml) RabbitMq Docs/ Web

### DIFF
--- a/docs/pages/databases/rabbitmq.en-US.mdx
+++ b/docs/pages/databases/rabbitmq.en-US.mdx
@@ -33,7 +33,7 @@ After deploying the Rabbitmq service, Zeabur will automatically inject the relev
 
 Sometimes, instead of using the above environment variables, you can add your own DATABASE_URL variable to simplify the URI declaration. For example:
 
-```bash copy
+```bash
 amqp://<RABBITMQ_DEFAULT_USER>:<RABBITMQ_DEFAULT_PASS>@<RABBITMQ_HOST>:<RABBITMQ_PORT>/<DATABASE_NAME>
 ```
 

--- a/docs/pages/databases/rabbitmq.en-US.mdx
+++ b/docs/pages/databases/rabbitmq.en-US.mdx
@@ -1,17 +1,17 @@
 ---
-title: Deploy RabbitMq Service
-ogImageTitle: Deploy RabbitMq Service
-ogImageSubtitle: Deploy RabbitMq Service with Zeabur
+title: Deploy RabbitMQ Service
+ogImageTitle: Deploy RabbitMQ Service
+ogImageSubtitle: Deploy RabbitMQ Service with Zeabur
 ---
 
 import {Callout} from 'nextra-theme-docs'
 
-# Deploy RabbitMq Service
+# Deploy RabbitMQ Service
 
-Zeabur provides RabbitMq service, allowing you to deploy RabbitMq message queue on Zeabur with just one click.
+Zeabur provides RabbitMQ service, allowing you to deploy RabbitMQ message queue on Zeabur with just one click.
 
 <Callout type="info" emoji="ℹ️">
-    Currently, the version of RabbitMq service is 3-management.
+    Currently, the version of RabbitMQ service is 3-management.
 </Callout>
 
 ## Deploy RabbitMQ Service

--- a/docs/pages/databases/rabbitmq.en-US.mdx
+++ b/docs/pages/databases/rabbitmq.en-US.mdx
@@ -16,15 +16,15 @@ Zeabur provides RabbitMQ service, allowing you to deploy RabbitMQ message queue 
 
 ## Deploy RabbitMQ Service
 
-In your project, click on **New Service**, then click on **Prebuilt** button. In the pop-up search bar, search for `Rabbitmq`.
+In your project, click on **New Service**, then click on **Prebuilt** button. In the pop-up search bar, search for `RabbitMQ`.
 
 ![deploy](/deploy/common/select-service.en-US.png)
 
-After clicking on deploy, Zeabur will automatically deploy the Rabbitmq service for you.
+After clicking on deploy, Zeabur will automatically deploy the RabbitMQ service for you.
 
 ## Environment Variables
 
-After deploying the Rabbitmq service, Zeabur will automatically inject the relevant environment variables into other services.
+After deploying the RabbitMQ service, Zeabur will automatically inject the relevant environment variables into other services.
 
 - `RABBITMQ_HOST`
 - `RABBITMQ_PORT`
@@ -41,10 +41,10 @@ Here, `<DATABASE_NAME>` is the name of the Vhost that you have added.
 
 ## Online Management Interface
 
-The Rabbitmq service provides an online management interface, allowing you to manage the Rabbitmq service in the browser.
+The RabbitMQ service provides an online management interface, allowing you to manage the RabbitMQ service in the browser.
 
-You can access the Rabbitmq service's online management interface by visiting `http://<RABBITMQ_HOST>:15672`.
+You can access the RabbitMQ service's online management interface by visiting `http://<RABBITMQ_HOST>:15672`.
 
 ## DSN settings
 
-You can use the DSN of the Rabbitmq service (that is, the connection string of the Rabbitmq service) through the variable `${RABBITMQ_URI}`.
+You can use the DSN of the RabbitMQ service (that is, the connection string of the RabbitMQ service) through the variable `${RABBITMQ_URI}`.

--- a/docs/pages/databases/rabbitmq.en-US.mdx
+++ b/docs/pages/databases/rabbitmq.en-US.mdx
@@ -47,4 +47,4 @@ You can access the RabbitMQ service's online management interface by visiting `h
 
 ## DSN settings
 
-You can use the DSN of the RabbitMQ service (that is, the connection string of the RabbitMQ service) through the variable `${RABBITMQ_URI}`.
+You can use the DSN of the RabbitMQ service (that is, the connection string of the RabbitMQ service) with the variable `${RABBITMQ_URI}`.

--- a/docs/pages/databases/rabbitmq.en-US.mdx
+++ b/docs/pages/databases/rabbitmq.en-US.mdx
@@ -1,0 +1,50 @@
+---
+title: Deploy RabbitMq Service
+ogImageTitle: Deploy RabbitMq Service
+ogImageSubtitle: Deploy RabbitMq Service with Zeabur
+---
+
+import {Callout} from 'nextra-theme-docs'
+
+# Deploy RabbitMq Service
+
+Zeabur provides RabbitMq service, allowing you to deploy RabbitMq message queue on Zeabur with just one click.
+
+<Callout type="info" emoji="ℹ️">
+    Currently, the version of RabbitMq service is 3-management.
+</Callout>
+
+## Deploy RabbitMQ Service
+
+In your project, click on **New Service**, then click on **Prebuilt** button. In the pop-up search bar, search for `Rabbitmq`.
+
+![deploy](/deploy/common/select-service.en-US.png)
+
+After clicking on deploy, Zeabur will automatically deploy the Rabbitmq service for you.
+
+## Environment Variables
+
+After deploying the Rabbitmq service, Zeabur will automatically inject the relevant environment variables into other services.
+
+- `RABBITMQ_HOST`
+- `RABBITMQ_PORT`
+- `RABBITMQ_DEFAULT_USER`
+- `RABBITMQ_DEFAULT_PASS`
+
+Sometimes, instead of using the above environment variables, you can use the self-added DATABASE_URL to replace them. For example:
+
+```bash copy
+amqp://<RABBITMQ_DEFAULT_USER>:<RABBITMQ_DEFAULT_PASS>@<RABBITMQ_HOST>:<RABBITMQ_PORT>/<DATABASE_NAME>
+```
+
+Here, `<DATABASE_NAME>` is the name of the Vhost that you have added.
+
+## Online Management Interface
+
+The Rabbitmq service provides an online management interface, allowing you to manage the Rabbitmq service in the browser.
+
+You can access the Rabbitmq service's online management interface by visiting `http://<RABBITMQ_HOST>:15672`.
+
+## DSN settings
+
+You can use the DSN of the Rabbitmq service (that is, the connection string of the Rabbitmq service) through the variable `${RABBITMQ_URI}`.

--- a/docs/pages/databases/rabbitmq.en-US.mdx
+++ b/docs/pages/databases/rabbitmq.en-US.mdx
@@ -31,7 +31,7 @@ After deploying the Rabbitmq service, Zeabur will automatically inject the relev
 - `RABBITMQ_DEFAULT_USER`
 - `RABBITMQ_DEFAULT_PASS`
 
-Sometimes, instead of using the above environment variables, you can use the self-added DATABASE_URL to replace them. For example:
+Sometimes, instead of using the above environment variables, you can add your own DATABASE_URL variable to simplify the URI declaration. For example:
 
 ```bash copy
 amqp://<RABBITMQ_DEFAULT_USER>:<RABBITMQ_DEFAULT_PASS>@<RABBITMQ_HOST>:<RABBITMQ_PORT>/<DATABASE_NAME>

--- a/docs/pages/databases/rabbitmq.zh-CN.mdx
+++ b/docs/pages/databases/rabbitmq.zh-CN.mdx
@@ -19,11 +19,9 @@ Zeabur 提供了 RabbitMQ 服务，让你可以在 Zeabur 上一键部署 Rabbit
 在你的项目中，点击 **新建服务**，点击 **预构建** ，在弹出列表搜索栏中搜索 `RabbitMQ`。
 
 ![deploy](/deploy/common/select-service.en-US.png)
-
 点击部署后，Zeabur 会自动帮你部署 RabbitMQ 服务。
 
 ## 环境变量
-
 当你部署 RabbitMQ 服务后，Zeabur 会自动帮你注入相关环境变量到其他的服务中。
 
  - `RABBITMQ_HOST`

--- a/docs/pages/databases/rabbitmq.zh-CN.mdx
+++ b/docs/pages/databases/rabbitmq.zh-CN.mdx
@@ -49,4 +49,3 @@ RabbitMQ 服务提供了一个在线管理界面，让你可以在浏览器中�
 
 你可以透过变量 `${RABBITMQ_URI}` 来使用 RabbitMQ 服务的 DSN（也就是 RabbitMQ 服务的网络地址）。
 
-

--- a/docs/pages/databases/rabbitmq.zh-CN.mdx
+++ b/docs/pages/databases/rabbitmq.zh-CN.mdx
@@ -1,0 +1,56 @@
+---
+title: 部署 RabbitMq 服务
+ogImageTitle: 部署 RabbitMq 服务
+ogImageSubtitle: 在 Zeabur 一键部署 RabbitMq 服务
+---
+
+
+
+import {Callout} from 'nextra-theme-docs'
+
+# Deploy RabbitMq 服务
+
+Zeabur 提供了 RabbitMq 服务，让你可以在 Zeabur 上一键部署 RabbitMq 消息队列。
+
+<Callout type="info" emoji="ℹ️">
+    目前 RabbitMq 服务版本为 3-management。
+</Callout>
+
+## 部署 RabbitMQ 服务
+
+在你的项目中，点击 **新建服务**，点击 **预构建** ，在弹出列表搜索栏中搜索 `Rabbitmq`。
+
+![deploy](/deploy/common/select-service.en-US.png)
+
+
+点击部署后，Zeabur 会自动帮你部署 Rabbitmq 服务。
+
+## 环境变量
+
+
+当你部署 Rabbitmq 服务后，Zeabur 会自动帮你注入相关环境变量到其他的服务中。
+
+ - `RABBITMQ_HOST`
+ - `RABBITMQ_PORT`
+ - `RABBITMQ_DEFAULT_USER`
+ - `RABBITMQ_DEFAULT_PASS`
+
+有时候我们可以用自行新增 `DATABASE_URL` 来取代上面的环境变量，例如：
+
+```bash copy
+amqp://<RABBITMQ_DEFAULT_USER>:<RABBITMQ_DEFAULT_PASS>@<RABBITMQ_HOST>:<RABBITMQ_PORT>/<DATABASE_NAME>
+```
+
+这里的 `<DATABASE_NAME>` 是你自行新增的 Vhost 名称。
+
+## 在线管理界面
+
+Rabbitmq 服务提供了一个在线管理界面，让你可以在浏览器中管理 Rabbitmq 服务。
+
+你通过访问 `http://<RABBITMQ_HOST>:15672` 来访问 Rabbitmq 服务的在线管理界面。
+
+## DSN 设定
+
+你可以透过变量 `${RABBITMQ_URI}` 来使用 Rabbitmq 服务的 DSN（也就是 Rabbitmq 服务的网络地址）。
+
+

--- a/docs/pages/databases/rabbitmq.zh-CN.mdx
+++ b/docs/pages/databases/rabbitmq.zh-CN.mdx
@@ -1,19 +1,19 @@
 ---
-title: 部署 RabbitMq 服务
-ogImageTitle: 部署 RabbitMq 服务
-ogImageSubtitle: 在 Zeabur 一键部署 RabbitMq 服务
+title: 部署 RabbitMQ 服务
+ogImageTitle: 部署 RabbitMQ 服务
+ogImageSubtitle: 在 Zeabur 一键部署 RabbitMQ 服务
 ---
 
 
 
 import {Callout} from 'nextra-theme-docs'
 
-# Deploy RabbitMq 服务
+# Deploy RabbitMQ 服务
 
-Zeabur 提供了 RabbitMq 服务，让你可以在 Zeabur 上一键部署 RabbitMq 消息队列。
+Zeabur 提供了 RabbitMQ 服务，让你可以在 Zeabur 上一键部署 RabbitMQ 消息队列。
 
 <Callout type="info" emoji="ℹ️">
-    目前 RabbitMq 服务版本为 3-management。
+    目前 RabbitMQ 服务版本为 3-management。
 </Callout>
 
 ## 部署 RabbitMQ 服务

--- a/docs/pages/databases/rabbitmq.zh-CN.mdx
+++ b/docs/pages/databases/rabbitmq.zh-CN.mdx
@@ -6,7 +6,7 @@ ogImageSubtitle: 在 Zeabur 一键部署 RabbitMQ 服务
 
 import {Callout} from 'nextra-theme-docs'
 
-# Deploy RabbitMQ 服务
+# 部署 RabbitMQ 服务
 
 Zeabur 提供了 RabbitMQ 服务，让你可以在 Zeabur 上一键部署 RabbitMQ 消息队列。
 

--- a/docs/pages/databases/rabbitmq.zh-CN.mdx
+++ b/docs/pages/databases/rabbitmq.zh-CN.mdx
@@ -16,15 +16,15 @@ Zeabur 提供了 RabbitMQ 服务，让你可以在 Zeabur 上一键部署 Rabbit
 
 ## 部署 RabbitMQ 服务
 
-在你的项目中，点击 **新建服务**，点击 **预构建** ，在弹出列表搜索栏中搜索 `Rabbitmq`。
+在你的项目中，点击 **新建服务**，点击 **预构建** ，在弹出列表搜索栏中搜索 `RabbitMQ`。
 
 ![deploy](/deploy/common/select-service.en-US.png)
 
-点击部署后，Zeabur 会自动帮你部署 Rabbitmq 服务。
+点击部署后，Zeabur 会自动帮你部署 RabbitMQ 服务。
 
 ## 环境变量
 
-当你部署 Rabbitmq 服务后，Zeabur 会自动帮你注入相关环境变量到其他的服务中。
+当你部署 RabbitMQ 服务后，Zeabur 会自动帮你注入相关环境变量到其他的服务中。
 
  - `RABBITMQ_HOST`
  - `RABBITMQ_PORT`
@@ -41,12 +41,12 @@ amqp://<RABBITMQ_DEFAULT_USER>:<RABBITMQ_DEFAULT_PASS>@<RABBITMQ_HOST>:<RABBITMQ
 
 ## 在线管理界面
 
-Rabbitmq 服务提供了一个在线管理界面，让你可以在浏览器中管理 Rabbitmq 服务。
+RabbitMQ 服务提供了一个在线管理界面，让你可以在浏览器中管理 RabbitMQ 服务。
 
-你通过访问 `http://<RABBITMQ_HOST>:15672` 来访问 Rabbitmq 服务的在线管理界面。
+你通过访问 `http://<RABBITMQ_HOST>:15672` 来访问 RabbitMQ 服务的在线管理界面。
 
 ## DSN 设定
 
-你可以透过变量 `${RABBITMQ_URI}` 来使用 Rabbitmq 服务的 DSN（也就是 Rabbitmq 服务的网络地址）。
+你可以透过变量 `${RABBITMQ_URI}` 来使用 RabbitMQ 服务的 DSN（也就是 RabbitMQ 服务的网络地址）。
 
 

--- a/docs/pages/databases/rabbitmq.zh-CN.mdx
+++ b/docs/pages/databases/rabbitmq.zh-CN.mdx
@@ -4,8 +4,6 @@ ogImageTitle: 部署 RabbitMQ 服务
 ogImageSubtitle: 在 Zeabur 一键部署 RabbitMQ 服务
 ---
 
-
-
 import {Callout} from 'nextra-theme-docs'
 
 # Deploy RabbitMQ 服务

--- a/docs/pages/databases/rabbitmq.zh-CN.mdx
+++ b/docs/pages/databases/rabbitmq.zh-CN.mdx
@@ -20,11 +20,9 @@ Zeabur 提供了 RabbitMQ 服务，让你可以在 Zeabur 上一键部署 Rabbit
 
 ![deploy](/deploy/common/select-service.en-US.png)
 
-
 点击部署后，Zeabur 会自动帮你部署 Rabbitmq 服务。
 
 ## 环境变量
-
 
 当你部署 Rabbitmq 服务后，Zeabur 会自动帮你注入相关环境变量到其他的服务中。
 
@@ -35,7 +33,7 @@ Zeabur 提供了 RabbitMQ 服务，让你可以在 Zeabur 上一键部署 Rabbit
 
 有时候我们可以用自行新增 `DATABASE_URL` 来取代上面的环境变量，例如：
 
-```bash copy
+```bash
 amqp://<RABBITMQ_DEFAULT_USER>:<RABBITMQ_DEFAULT_PASS>@<RABBITMQ_HOST>:<RABBITMQ_PORT>/<DATABASE_NAME>
 ```
 

--- a/docs/pages/databases/rabbitmq.zh-TW.mdx
+++ b/docs/pages/databases/rabbitmq.zh-TW.mdx
@@ -4,24 +4,23 @@ ogImageTitle: 部署 RabbitMQ 服務
 ogImageSubtitle: 在 Zeabur 一鍵部署 RabbitMQ 服務
 ---
 
-
 import {Callout} from 'nextra-theme-docs'
 
 # 部署 RabbitMQ 服務
 
-Zeabur 提供了 RabbitMQ 服務，讓你可以在 Zeabur 上一鍵部署 RabbitMQ 消息隊列。
+Zeabur 提供了 RabbitMQ 服務，讓你可以在 Zeabur 上一鍵部署 RabbitMQ 消息佇列。
 
 <Callout type="info" emoji="ℹ️">
-    目前 RabbitMQ 服務版本為 `3-management`。
+    目前 RabbitMQ 服務版本為 3-management。
 </Callout>
 
 ## 部署 RabbitMQ 服務
 
-在你的項目中，點擊 **新建服務**，點擊 **預構建** ，在彈出列表搜索欄中搜索 `RabbitMQ`。
+在你的專案中，點選 **建立服務** → **Prebuilt** ，在彈出列表搜尋列中搜尋 `RabbitMQ`。
 
 ![deploy](/deploy/common/select-service.en-US.png)
 
-點擊部署後，Zeabur 會自動幫你部署 RabbitMQ 服務。
+點選部署後，Zeabur 會自動幫你部署 RabbitMQ 服務。
 
 ## 環境變數
 
@@ -40,11 +39,11 @@ amqp://<RABBITMQ_DEFAULT_USER>:<RABBITMQ_DEFAULT_PASS>@<RABBITMQ_HOST>:<RABBITMQ
 
 這裡的 <DATABASE_NAME> 是你自行新增的 Vhost 名稱。
 
-## 在線管理界面
+## 線上管理介面
 
-RabbitMQ 服務提供了一個在線管理界面，讓你可以在瀏覽器中管理 RabbitMQ 服務。
+RabbitMQ 服務提供了一個線上管理介面，讓你可以在瀏覽器中管理 RabbitMQ 服務。
 
-你通過訪問 `http://<RABBITMQ_HOST>:15672` 來訪問 RabbitMQ 服務的在線管理界面。
+可以進入 `http://<RABBITMQ_HOST>:15672` 來使用 RabbitMQ 服務的線上管理介面
 
 ## DSN 設定
 

--- a/docs/pages/databases/rabbitmq.zh-TW.mdx
+++ b/docs/pages/databases/rabbitmq.zh-TW.mdx
@@ -4,11 +4,12 @@ ogImageTitle: 部署 RabbitMQ 服務
 ogImageSubtitle: 在 Zeabur 一鍵部署 RabbitMQ 服務
 ---
 
+
 import {Callout} from 'nextra-theme-docs'
 
 # 部署 RabbitMQ 服務
 
-Zeabur 提供了 RabbitMQ 服務，讓你可以在 Zeabur 上一鍵部署 RabbitMQ 訊息佇列。
+Zeabur 提供了 RabbitMQ 服務，讓你可以在 Zeabur 上一鍵部署 RabbitMQ 消息隊列。
 
 <Callout type="info" emoji="ℹ️">
     目前 RabbitMQ 服務版本為 `3-management`。
@@ -16,36 +17,35 @@ Zeabur 提供了 RabbitMQ 服務，讓你可以在 Zeabur 上一鍵部署 Rabbit
 
 ## 部署 RabbitMQ 服務
 
-在你的專案中，點擊 **新建服務**，點擊 **預構建** ，在彈出列表搜索欄中搜索 `Rabbitmq`。
+在你的項目中，點擊 **新建服務**，點擊 **預構建** ，在彈出列表搜索欄中搜索 `Rabbitmq`。
 
 ![deploy](/deploy/common/select-service.en-US.png)
-
 
 點擊部署後，Zeabur 會自動幫你部署 Rabbitmq 服務。
 
 ## 環境變數
 
-當你部署 Rabbitmq 服務後，Zeabur 會自動為其他服務注入相關環境變數。
+當你部署 Rabbitmq 服務後，Zeabur 會自動幫你注入相關環境變數到其他的服務中。
 
  - `RABBITMQ_HOST`
  - `RABBITMQ_PORT`
  - `RABBITMQ_DEFAULT_USER`
  - `RABBITMQ_DEFAULT_PASS`
 
-有時候我們也可以用自行新增的 DATABASE_URL 來取代上面的環境變數，例如：
+有時候我們可以用自行新增 DATABASE_URL 來取代上面的環境變數，例如：
 
-```bash copy
-DATABASE_URL=amqp://<RABBITMQ_DEFAULT_USER>:<RABBITMQ_DEFAULT_PASS>@<RABBITMQ_HOST>:<RABBITMQ_PORT>/<DATABASE_NAME>
+```bash
+amqp://<RABBITMQ_DEFAULT_USER>:<RABBITMQ_DEFAULT_PASS>@<RABBITMQ_HOST>:<RABBITMQ_PORT>/<DATABASE_NAME>
 ```
-這裡的 `<DATABASE_NAME>` 是你自行新增的 Vhost 名稱。
 
-## 線上管理介面
+這裡的 <DATABASE_NAME> 是你自行新增的 Vhost 名稱。
 
-Rabbitmq 服務提供了一個線上管理介面，讓你可以在瀏覽器中管理 Rabbitmq 服務。
+## 在線管理界面
 
-你可以透過訪問 `http://<RABBITMQ_HOST>:15672` 來使用 Rabbitmq 服務的線上管理介面。
+Rabbitmq 服務提供了一個在線管理界面，讓你可以在瀏覽器中管理 Rabbitmq 服務。
+
+你通過訪問 `http://<RABBITMQ_HOST>:15672` 來訪問 Rabbitmq 服務的在線管理界面。
 
 ## DSN 設定
 
-你可以透過变量 ${RABBITMQ_URI} 來使用 Rabbitmq 服務的 DSN（也就是 Rabbitmq 服務的連線字串）。
-
+你可以透過變數 ${RABBITMQ_URI} 來使用 Rabbitmq 服務的 DSN（也就是 Rabbitmq 服務的網路地址）。

--- a/docs/pages/databases/rabbitmq.zh-TW.mdx
+++ b/docs/pages/databases/rabbitmq.zh-TW.mdx
@@ -31,13 +31,10 @@ Zeabur 提供了 RabbitMQ 服務，讓你可以在 Zeabur 上一鍵部署 Rabbit
  - `RABBITMQ_DEFAULT_USER`
  - `RABBITMQ_DEFAULT_PASS`
 
-有時候我們可以用自行新增 DATABASE_URL 來取代上面的環境變數，例如：
+有時候我們可以用自行新增的 `DATABASE_URL` 來取代上面的環境變數，例如：
 
 ```bash
 amqp://<RABBITMQ_DEFAULT_USER>:<RABBITMQ_DEFAULT_PASS>@<RABBITMQ_HOST>:<RABBITMQ_PORT>/<DATABASE_NAME>
-```
-
-這裡的 <DATABASE_NAME> 是你自行新增的 Vhost 名稱。
 
 ## 線上管理介面
 

--- a/docs/pages/databases/rabbitmq.zh-TW.mdx
+++ b/docs/pages/databases/rabbitmq.zh-TW.mdx
@@ -1,17 +1,17 @@
 ---
-title: 部署 RabbitMq 服務
-ogImageTitle: 部署 RabbitMq 服務
-ogImageSubtitle: 在 Zeabur 一鍵部署 RabbitMq 服務
+title: 部署 RabbitMQ 服務
+ogImageTitle: 部署 RabbitMQ 服務
+ogImageSubtitle: 在 Zeabur 一鍵部署 RabbitMQ 服務
 ---
 
 import {Callout} from 'nextra-theme-docs'
 
-# 部署 RabbitMq 服務
+# 部署 RabbitMQ 服務
 
-Zeabur 提供了 RabbitMq 服務，讓你可以在 Zeabur 上一鍵部署 RabbitMq 訊息佇列。
+Zeabur 提供了 RabbitMQ 服務，讓你可以在 Zeabur 上一鍵部署 RabbitMQ 訊息佇列。
 
 <Callout type="info" emoji="ℹ️">
-    目前 RabbitMq 服務版本為 `3-management`。
+    目前 RabbitMQ 服務版本為 `3-management`。
 </Callout>
 
 ## 部署 RabbitMQ 服務

--- a/docs/pages/databases/rabbitmq.zh-TW.mdx
+++ b/docs/pages/databases/rabbitmq.zh-TW.mdx
@@ -36,6 +36,8 @@ Zeabur 提供了 RabbitMQ 服務，讓你可以在 Zeabur 上一鍵部署 Rabbit
 ```bash
 amqp://<RABBITMQ_DEFAULT_USER>:<RABBITMQ_DEFAULT_PASS>@<RABBITMQ_HOST>:<RABBITMQ_PORT>/<DATABASE_NAME>
 
+這裡的 <DATABASE_NAME> 是你自行新增的 Vhost 名稱。
+
 ## 線上管理介面
 
 RabbitMQ 服務提供了一個線上管理介面，讓你可以在瀏覽器中管理 RabbitMQ 服務。

--- a/docs/pages/databases/rabbitmq.zh-TW.mdx
+++ b/docs/pages/databases/rabbitmq.zh-TW.mdx
@@ -35,6 +35,7 @@ Zeabur 提供了 RabbitMQ 服務，讓你可以在 Zeabur 上一鍵部署 Rabbit
 
 ```bash
 amqp://<RABBITMQ_DEFAULT_USER>:<RABBITMQ_DEFAULT_PASS>@<RABBITMQ_HOST>:<RABBITMQ_PORT>/<DATABASE_NAME>
+```
 
 這裡的 <DATABASE_NAME> 是你自行新增的 Vhost 名稱。
 

--- a/docs/pages/databases/rabbitmq.zh-TW.mdx
+++ b/docs/pages/databases/rabbitmq.zh-TW.mdx
@@ -17,15 +17,15 @@ Zeabur 提供了 RabbitMQ 服務，讓你可以在 Zeabur 上一鍵部署 Rabbit
 
 ## 部署 RabbitMQ 服務
 
-在你的項目中，點擊 **新建服務**，點擊 **預構建** ，在彈出列表搜索欄中搜索 `Rabbitmq`。
+在你的項目中，點擊 **新建服務**，點擊 **預構建** ，在彈出列表搜索欄中搜索 `RabbitMQ`。
 
 ![deploy](/deploy/common/select-service.en-US.png)
 
-點擊部署後，Zeabur 會自動幫你部署 Rabbitmq 服務。
+點擊部署後，Zeabur 會自動幫你部署 RabbitMQ 服務。
 
 ## 環境變數
 
-當你部署 Rabbitmq 服務後，Zeabur 會自動幫你注入相關環境變數到其他的服務中。
+當你部署 RabbitMQ 服務後，Zeabur 會自動幫你注入相關環境變數到其他的服務中。
 
  - `RABBITMQ_HOST`
  - `RABBITMQ_PORT`
@@ -42,10 +42,10 @@ amqp://<RABBITMQ_DEFAULT_USER>:<RABBITMQ_DEFAULT_PASS>@<RABBITMQ_HOST>:<RABBITMQ
 
 ## 在線管理界面
 
-Rabbitmq 服務提供了一個在線管理界面，讓你可以在瀏覽器中管理 Rabbitmq 服務。
+RabbitMQ 服務提供了一個在線管理界面，讓你可以在瀏覽器中管理 RabbitMQ 服務。
 
-你通過訪問 `http://<RABBITMQ_HOST>:15672` 來訪問 Rabbitmq 服務的在線管理界面。
+你通過訪問 `http://<RABBITMQ_HOST>:15672` 來訪問 RabbitMQ 服務的在線管理界面。
 
 ## DSN 設定
 
-你可以透過變數 ${RABBITMQ_URI} 來使用 Rabbitmq 服務的 DSN（也就是 Rabbitmq 服務的網路地址）。
+你可以透過變數 ${RABBITMQ_URI} 來使用 RabbitMQ 服務的 DSN（也就是 RabbitMQ 服務的網路地址）。

--- a/docs/pages/databases/rabbitmq.zh-TW.mdx
+++ b/docs/pages/databases/rabbitmq.zh-TW.mdx
@@ -1,0 +1,51 @@
+---
+title: 部署 RabbitMq 服務
+ogImageTitle: 部署 RabbitMq 服務
+ogImageSubtitle: 在 Zeabur 一鍵部署 RabbitMq 服務
+---
+
+import {Callout} from 'nextra-theme-docs'
+
+# 部署 RabbitMq 服務
+
+Zeabur 提供了 RabbitMq 服務，讓你可以在 Zeabur 上一鍵部署 RabbitMq 訊息佇列。
+
+<Callout type="info" emoji="ℹ️">
+    目前 RabbitMq 服務版本為 `3-management`。
+</Callout>
+
+## 部署 RabbitMQ 服務
+
+在你的專案中，點擊 **新建服務**，點擊 **預構建** ，在彈出列表搜索欄中搜索 `Rabbitmq`。
+
+![deploy](/deploy/common/select-service.en-US.png)
+
+
+點擊部署後，Zeabur 會自動幫你部署 Rabbitmq 服務。
+
+## 環境變數
+
+當你部署 Rabbitmq 服務後，Zeabur 會自動為其他服務注入相關環境變數。
+
+ - `RABBITMQ_HOST`
+ - `RABBITMQ_PORT`
+ - `RABBITMQ_DEFAULT_USER`
+ - `RABBITMQ_DEFAULT_PASS`
+
+有時候我們也可以用自行新增的 DATABASE_URL 來取代上面的環境變數，例如：
+
+```bash copy
+DATABASE_URL=amqp://<RABBITMQ_DEFAULT_USER>:<RABBITMQ_DEFAULT_PASS>@<RABBITMQ_HOST>:<RABBITMQ_PORT>/<DATABASE_NAME>
+```
+這裡的 `<DATABASE_NAME>` 是你自行新增的 Vhost 名稱。
+
+## 線上管理介面
+
+Rabbitmq 服務提供了一個線上管理介面，讓你可以在瀏覽器中管理 Rabbitmq 服務。
+
+你可以透過訪問 `http://<RABBITMQ_HOST>:15672` 來使用 Rabbitmq 服務的線上管理介面。
+
+## DSN 設定
+
+你可以透過变量 ${RABBITMQ_URI} 來使用 Rabbitmq 服務的 DSN（也就是 Rabbitmq 服務的連線字串）。
+

--- a/prebuilts/rabbitmq.toml
+++ b/prebuilts/rabbitmq.toml
@@ -15,6 +15,11 @@ id = "database"
 port = 5672
 type = "TCP"
 
+[[ports]]
+id = "web"
+port = 15672
+type = "HTTP"
+
 [[volumes]]
 id = "data"
 dir = "/var/lib/rabbitmq" # default data directories.

--- a/prebuilts/rabbitmq.toml
+++ b/prebuilts/rabbitmq.toml
@@ -20,7 +20,6 @@ id = "web"
 port = 15672
 type = "HTTP"
 
-
 [[volumes]]
 id = "data"
 dir = "/var/lib/rabbitmq" # default data directories.

--- a/prebuilts/rabbitmq.toml
+++ b/prebuilts/rabbitmq.toml
@@ -1,0 +1,71 @@
+#:schema ./schema.json
+# 待审查
+
+id = "rabbitmq"
+name = "RabbitMQ"
+
+# TODO Download svg icon from https://www.svgrepo.com/svg/303576/rabbitmq-logo
+icon = "https://raw.githubusercontent.com/zeabur/service-icons/main/marketplace/rabbitmq.svg"
+
+description = "RabbitMQ is a widely used open-source message broker that implements the Advanced Message Queuing Protocol (AMQP)"
+
+[source]
+image = "rabbitmq:3-management"
+
+[[ports]]
+id = "database"
+port = 5672
+type = "TCP"
+
+[[volumes]]
+id = "data"
+# mountPath = "/var/lib/rabbitmq"
+dir = "/data/rabbitmq" # TODO
+
+
+
+[env]
+RABBITMQ_DEFAULT_USER = { default = "admin" } # or guest?
+RABBITMQ_DEFAULT_PASS = { default = "${PASSWORD}" }
+
+RABBITMQ_DEFAULT_VHOST = { default = "/" }
+
+RABBITMQ_HOST = { default = "${CONTAINER_HOSTNAME}", expose = true, readonly = true }
+RABBITMQ_PORT = { default = "${DATABASE_PORT}", expose = true, readonly = true }
+
+
+RABBITMQ_CONNECTION_STRING = { default = "amqp://${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}@${RABBITMQ_HOST}:${RABBITMQ_PORT}", expose = true, readonly = true }
+RABBITMQ_URI = { default = "${RABBITMQ_CONNECTION_STRING}", expose = true, readonly = true }
+
+[[instructions]]
+type = "TEXT"
+title = "Command to connect to your RabbitMQ"
+# TODO RabbitMQ cli is not wide used,check https://serverfault.com/a/961291 https://stackoverflow.com/a/56140362
+content = "rabbitmqadmin --host ${PORT_FORWARDED_HOSTNAME} --port ${DATABASE_PORT_FORWARDED_PORT} --username ${RABBITMQ_DEFAULT_USER} --password ${RABBITMQ_DEFAULT_PASS} --vhost ${RABBITMQ_DEFAULT_VHOST} list queues"
+showWhen = "PORT_FORWARDING"
+
+[[instructions]]
+type = "TEXT"
+title = "RabbitMQ username"
+content = "${RABBITMQ_DEFAULT_USER}"
+category = "Credentials"
+
+
+[[instructions]]
+type = "PASSWORD"
+title = "RabbitMQ password"
+content = "${RABBITMQ_DEFAULT_PASS}"
+category = "Credentials"
+
+[[instructions]]
+type = "TEXT"
+title = "RabbitMQ host"
+content = "${PORT_FORWARDED_HOSTNAME}"
+showWhen = "PORT_FORWARDING"
+category = "Hostname & Port"
+
+[[instructions]]
+type = "TEXT"
+title = "RabbitMQ port"
+content = "${DATABASE_PORT_FORWARDED_PORT}"
+category = "Hostname & Port"

--- a/prebuilts/rabbitmq.toml
+++ b/prebuilts/rabbitmq.toml
@@ -1,10 +1,8 @@
 #:schema ./schema.json
-# 待审查
 
 id = "rabbitmq"
 name = "RabbitMQ"
 
-# TODO Download svg icon from https://www.svgrepo.com/svg/303576/rabbitmq-logo
 icon = "https://raw.githubusercontent.com/zeabur/service-icons/main/marketplace/rabbitmq.svg"
 
 description = "RabbitMQ is a widely used open-source message broker that implements the Advanced Message Queuing Protocol (AMQP)"
@@ -19,8 +17,7 @@ type = "TCP"
 
 [[volumes]]
 id = "data"
-# mountPath = "/var/lib/rabbitmq"
-dir = "/data/rabbitmq" # TODO
+dir = "/var/lib/rabbitmq" # default data directories.
 
 
 
@@ -32,17 +29,9 @@ RABBITMQ_DEFAULT_VHOST = { default = "/" }
 
 RABBITMQ_HOST = { default = "${CONTAINER_HOSTNAME}", expose = true, readonly = true }
 RABBITMQ_PORT = { default = "${DATABASE_PORT}", expose = true, readonly = true }
-
-
 RABBITMQ_CONNECTION_STRING = { default = "amqp://${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}@${RABBITMQ_HOST}:${RABBITMQ_PORT}", expose = true, readonly = true }
 RABBITMQ_URI = { default = "${RABBITMQ_CONNECTION_STRING}", expose = true, readonly = true }
 
-[[instructions]]
-type = "TEXT"
-title = "Command to connect to your RabbitMQ"
-# TODO RabbitMQ cli is not wide used,check https://serverfault.com/a/961291 https://stackoverflow.com/a/56140362
-content = "rabbitmqadmin --host ${PORT_FORWARDED_HOSTNAME} --port ${DATABASE_PORT_FORWARDED_PORT} --username ${RABBITMQ_DEFAULT_USER} --password ${RABBITMQ_DEFAULT_PASS} --vhost ${RABBITMQ_DEFAULT_VHOST} list queues"
-showWhen = "PORT_FORWARDING"
 
 [[instructions]]
 type = "TEXT"


### PR DESCRIPTION
## Whats Changed
- create `docs/pages/databases/rabbitmq.en-US.mdx`
- create `docs/pages/databases/rabbitmq.zh-CN.mdx`
- create `docs/pages/databases/rabbitmq.zh-TW.mdx`
- update `prebuilts/rabbitmq.toml`

## Web Management
```
Management Plugin

There is a second set of tags provided with the [management plugin](https://www.rabbitmq.com/management.html) installed and enabled by default, which is available on the standard management port of 15672, with the default username and password of guest / guest:

$ docker run -d --hostname my-rabbit --name some-rabbit rabbitmq:3-management

You can access it by visiting http://container-ip:15672 in a browser or, if you need access outside the host, on port 8080:

$ docker run -d --hostname my-rabbit --name some-rabbit -p 8080:15672 rabbitmq:3-management

You can then go to http://localhost:8080 或 http://host-ip:8080 in a browser.
```
Docs from https://hub.docker.com/_/rabbitmq