### PR TITLE
docs: fix typo in nodejs guide

### DIFF
--- a/docs/pages/guides/nodejs.en-US.mdx
+++ b/docs/pages/guides/nodejs.en-US.mdx
@@ -279,7 +279,7 @@ Don't forget to install `esbuild` in your project after adding this script, and 
 
 You can find the complete sample code at [zeabur/expressjs-template](https://github.com/zeabur/expressjs-template) or modify the `scripts/build.js` script according to your needs.
 
-## Addditional Notes
+## Additional Notes
 1. The port to listen to should use `process.env.PORT`
 
 For example:


### PR DESCRIPTION
Close #339 