### PR TITLE
refactor: remove unused environment variables

### DIFF
--- a/prebuilts/featbit-data-analytics-server.toml
+++ b/prebuilts/featbit-data-analytics-server.toml
@@ -14,7 +14,5 @@ port = 80
 type = "HTTP"
 
 [env]
-MONGO_URI = { default = "${MONGO_CONNECTION_STRING}" }
 MONGO_INITDB_DATABASE = { default = "featbit" }
-MONGO_HOST = { default = "mongodb.zeabur.internal" }
 CHECK_DB_LIVNESS = { default = "true" }


### PR DESCRIPTION
`MONGO_URI` and `MONGO_HOST` been implicitly injected into services.

https://github.com/zeabur/zeabur/blob/main/prebuilts/mongodb.toml