### PR TITLE
prebuilt: add linkwarden

### DIFF
--- a/prebuilts/linkwarden.toml
+++ b/prebuilts/linkwarden.toml
@@ -16,3 +16,6 @@ type = "HTTP"
 [[volumes]]
 id = "data"
 dir = "/data"
+
+[env]
+DATABASE_URL = { default = "${POSTGRES_CONNECTION_STRING}" }

--- a/prebuilts/linkwarden.toml
+++ b/prebuilts/linkwarden.toml
@@ -1,0 +1,18 @@
+#:schema ./schema.json
+
+id = "linkwarden"
+name = "Linkwarden"
+icon = "https://github.com/linkwarden/linkwarden/raw/main/assets/logo.png"
+description = "Collaborative bookmark manager to collect, organize and archive webpages"
+
+[source]
+image = "saifbenali/linkwarden:v2.5.1"
+
+[[ports]]
+id = "web"
+port = 3000
+type = "HTTP"
+
+[[volumes]]
+id = "data"
+dir = "/data"


### PR DESCRIPTION
Linkwarden is a collaborative bookmark manager to collect, organize and archive webpages.
Solves #381 

References: https://hub.docker.com/layers/saifbenali/linkwarden/v2.5.1/images/sha256-1aa951c23bca24c16b536c79ac522c5dad05b6bb6f9a08cabc7327b3bb3db8c2?context=explore