### PR TITLE
chore(prebuilt): bump halo version to 2.14

### DIFF
--- a/prebuilts/halo.toml
+++ b/prebuilts/halo.toml
@@ -7,7 +7,7 @@ docs = "https://zeabur.com/docs/marketplace/halo"
 description = "Halo is a powerful and easy-to-use open source website building tool."
 
 [source]
-image = "halohub/halo:2.10"
+image = "halohub/halo:2.14"
 
 [[ports]]
 id = "web"


### PR DESCRIPTION
Bump Halo version to 2.14

- https://github.com/halo-dev/halo/releases/tag/v2.14.0
- https://github.com/halo-dev/halo/releases/tag/v2.13.0
- https://github.com/halo-dev/halo/releases/tag/v2.12.0
- https://github.com/halo-dev/halo/releases/tag/v2.11.0