### PR TITLE
fix(prebuilts): rss3 node template endpoint should have https:// prefix

### DIFF
--- a/prebuilts/rss3-node.toml
+++ b/prebuilts/rss3-node.toml
@@ -16,7 +16,7 @@ port = 80
 type = "HTTP"
 
 [env]
-NODE_DISCOVERY_SERVER_ENDPOINT = { default = "${ZEABUR_WEB_URL}" }
+NODE_DISCOVERY_SERVER_ENDPOINT = { default = "https://${ZEABUR_WEB_URL}" }
 NODE_DISCOVERY_SERVER_GLOBAL_INDEXER_ENDPOINT = { default = "https://gi.rss3.io" }
 NODE_DISCOVERY_MAINTAINER_EVM_ADDRESS = { required = true }
 NODE_DISCOVERY_MAINTAINER_SIGNATURE = { required = true }


### PR DESCRIPTION
This won't affect the alpha node though. But after alpha (i.e., since beta), the URL needs to be complete; otherwise, an error will be thrown when running the node.

/cc @polebug 