### PR TITLE
fix(prebuilts): use correct envs for database and redis

### DIFF
--- a/prebuilts/directus.toml
+++ b/prebuilts/directus.toml
@@ -26,13 +26,11 @@ KEY = { default = "${PASSWORD}" }
 SECRET = { default = "${PASSWORD}" }
 
 DB_CLIENT = { default = "pg" }
-DB_HOST = { default = "${POSTGRES_HOST}" }
-DB_USER = { default = "${POSTGRES_USERNAME}" }
-DB_PASSWORD = { default = "${POSTGRES_PASSWORD}" }
+DB_CONNECTION_STRING = { default = "${POSTGRES_CONNECTION_STRING}"}
 
 CACHE_ENABLED = { default = "true" }
 CACHE_STORE = { default = "redis" }
-REDIS = { default = "${REDIS_HOST}" }
+REDIS = { default = "${REDIS_URI}" }
 
 PUBLIC_URL = { default = "${ZEABUR_WEB_URL}" }
 


### PR DESCRIPTION
This PR updates the default values for the following environment variables to make it easier for users to get started with Directus:

- `DB_XXX` is alternative by `DB_CONNECTION_STRING`.
- `REDIS` is now `REDIS_URI`.

The previous value for `REDIS` did not include a username or password, which caused authorization to fail. This PR updates the default value to include a username and password, so that users can get started with Redis without having to manually configure it.