### PR TITLE
feat(prebuilts): add directus admin info to instruction sections

### DIFF
--- a/prebuilts/directus.toml
+++ b/prebuilts/directus.toml
@@ -36,3 +36,15 @@ PUBLIC_URL = { default = "${ZEABUR_WEB_URL}" }
 
 ADMIN_EMAIL = { required = true }
 ADMIN_PASSWORD = { default = "${PASSWORD}" }
+
+[[instructions]]
+type = "TEXT"
+title = "Admin Email"
+content = "${ADMIN_EMAIL}"
+category = "Credentials"
+
+[[instructions]]
+type = "PASSWORD"
+title = "Admin Password"
+content = "${ADMIN_PASSWORD}"
+category = "Credentials"


### PR DESCRIPTION
This PR add some admin information to instruction sections:

- Admin Email
- Admin Password