### PR TITLE
fix: Deploy CLI link errors

### DIFF
--- a/docs/pages/guides/dart/flutter.en-US.mdx
+++ b/docs/pages/guides/dart/flutter.en-US.mdx
@@ -44,7 +44,7 @@ You can click the `Use this template` button on the GitHub page to use the templ
 
 ### Method 1: Using Zeabur CLI
 
-First, make sure you have installed the Zeabur CLI according to the [Zeabur CLI deployment guide](../deploy/deploy-in-cli).
+First, make sure you have installed the Zeabur CLI according to the [Zeabur CLI deployment guide](/deploy/deploy-in-cli).
 
 Then, in your newly initialized Flutter project, add the files that are not yet committed to version control to Git.
 

--- a/docs/pages/guides/dart/flutter.ja-JP.mdx
+++ b/docs/pages/guides/dart/flutter.ja-JP.mdx
@@ -44,7 +44,7 @@ GitHubページで`Use this template`ボタンをクリックして、テンプ�
 
 ### 方法1：Zeabur CLIを使用する
 
-まず、[Zeabur CLIデプロイガイド](../deploy/deploy-in-cli)に従ってZeabur CLIをインストールしていることを確認してください。
+まず、[Zeabur CLIデプロイガイド](/deploy/deploy-in-cli)に従ってZeabur CLIをインストールしていることを確認してください。
 
 次に、新しく初期化したFlutterプロジェクトで、バージョン管理にまだコミットされていないファイルをGitに追加します。
 

--- a/docs/pages/guides/dart/flutter.zh-CN.mdx
+++ b/docs/pages/guides/dart/flutter.zh-CN.mdx
@@ -44,7 +44,7 @@ flutter run -d chrome
 
 ### 方法一：使用 Zeabur CLI
 
-首先，确保你已经按照 [Zeabur CLI 部署指南](../deploy/deploy-in-cli) 安装好了 Zeabur CLI。
+首先，确保你已经按照 [Zeabur CLI 部署指南](/deploy/deploy-in-cli) 安装好了 Zeabur CLI。
 
 然后，在你刚初始化好的 Flutter 项目中，将尚未提交到版本控制的文件加入到 Git 中。
 

--- a/docs/pages/guides/dart/flutter.zh-TW.mdx
+++ b/docs/pages/guides/dart/flutter.zh-TW.mdx
@@ -44,7 +44,7 @@ flutter run -d chrome
 
 ### 方法一：使用 Zeabur CLI
 
-首先，確保你已經按照 [Zeabur CLI](../deploy/deploy-in-cli) 的指南安裝好了 Zeabur CLI。
+首先，確保你已經按照 [Zeabur CLI](/deploy/deploy-in-cli) 的指南安裝好了 Zeabur CLI。
 
 然後，在你剛初始化好的 Flutter 專案中，將尚未提交到版本控制的檔案加入到 Git 中。
 

--- a/docs/pages/guides/nodejs/astro.en-US.mdx
+++ b/docs/pages/guides/nodejs/astro.en-US.mdx
@@ -47,7 +47,7 @@ With that, your Astro project is ready to be deployed to Zeabur.
 
 ### Method 1: Using the Zeabur CLI
 
-First, ensure that you have installed the Zeabur CLI according to the guide [Deploy in CLI](../deploy/deploy-in-cli).
+First, ensure that you have installed the Zeabur CLI according to the guide [Deploy in CLI](/deploy/deploy-in-cli).
 
 Then, in your newly initialized Astro project, add uncommitted files to Git.
 

--- a/docs/pages/guides/nodejs/astro.ja-JP.mdx
+++ b/docs/pages/guides/nodejs/astro.ja-JP.mdx
@@ -47,7 +47,7 @@ export default {
 
 ### 方法1：Zeabur CLIを使用する
 
-まず、[Zeabur CLIのデプロイ](../deploy/deploy-in-cli)ガイドに従ってZeabur CLIがインストールされていることを確認してください。
+まず、[Zeabur CLIのデプロイ](/deploy/deploy-in-cli)ガイドに従ってZeabur CLIがインストールされていることを確認してください。
 
 次に、新しく初期化されたAstroプロジェクトで、バージョン管理にコミットされていないファイルをGitに追加します。
 

--- a/docs/pages/guides/nodejs/astro.zh-CN.mdx
+++ b/docs/pages/guides/nodejs/astro.zh-CN.mdx
@@ -47,7 +47,7 @@ export default {
 
 ### 方法一：使用 Zeabur CLI
 
-首先，确保你已经按照 [Zeabur CLI 部署](../deploy/deploy-in-cli) 的指南安装好了 Zeabur CLI。
+首先，确保你已经按照 [Zeabur CLI 部署](/deploy/deploy-in-cli) 的指南安装好了 Zeabur CLI。
 
 然后，在你刚初始化好的 Astro 项目中，将尚未提交到版本控制的文件加入到 Git 中。
 

--- a/docs/pages/guides/nodejs/astro.zh-TW.mdx
+++ b/docs/pages/guides/nodejs/astro.zh-TW.mdx
@@ -47,7 +47,7 @@ export default {
 
 ### 方法一：使用 Zeabur CLI
 
-首先，確保你已經按照 [Zeabur CLI](../deploy/deploy-in-cli) 的指南安裝好了 Zeabur CLI。
+首先，確保你已經按照 [Zeabur CLI](/deploy/deploy-in-cli) 的指南安裝好了 Zeabur CLI。
 
 然後，在你剛初始化好的 Astro 專案中，將尚未提交到版本控制的檔案加入到 Git 中。
 

--- a/docs/pages/guides/nodejs/svelte-kit.en-US.mdx
+++ b/docs/pages/guides/nodejs/svelte-kit.en-US.mdx
@@ -77,7 +77,7 @@ export default {
 
 ### Method 1: Using the Zeabur CLI
 
-First, ensure that you have installed the Zeabur CLI according to the guide [Deploy in CLI](../deploy/deploy-in-cli).
+First, ensure that you have installed the Zeabur CLI according to the guide [Deploy in CLI](/deploy/deploy-in-cli).
 
 Then, in your newly initialized Svelte Kit project, add uncommitted files to Git.
 

--- a/docs/pages/guides/nodejs/svelte-kit.zh-TW.mdx
+++ b/docs/pages/guides/nodejs/svelte-kit.zh-TW.mdx
@@ -77,7 +77,7 @@ export default {
 
 ### 方法一：使用 Zeabur CLI
 
-首先，確保你已經按照 [Zeabur CLI](../deploy/deploy-in-cli) 的指南安裝好了 Zeabur CLI。
+首先，確保你已經按照 [Zeabur CLI](/deploy/deploy-in-cli) 的指南安裝好了 Zeabur CLI。
 
 然後，在你剛初始化好的 Svelte Kit 專案中，將尚未提交到版本控制的檔案加入到 Git 中。
 


### PR DESCRIPTION
In the docs for Astro, Flutter, and Sveltekit, the "Deploy in CLI" links redirect to an error page due to faulty link. This pull request seeks to replace it with the correct link.