### PR TITLE
chore: Disable reference lint

### DIFF
--- a/.github/workflows/check-prebuilts.yml
+++ b/.github/workflows/check-prebuilts.yml
@@ -16,12 +16,12 @@ jobs:
       - run: python3 ../scripts/check-prebuilts.py
         working-directory: prebuilts
 
-  check-prebuilts-references:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.12'
-      - run: python3 ../scripts/check-prebuilts-variable-refs.py
-        working-directory: prebuilts
+  # check-prebuilts-references:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: actions/setup-python@v4
+  #       with:
+  #         python-version: '3.12'
+  #     - run: python3 ../scripts/check-prebuilts-variable-refs.py
+  #       working-directory: prebuilts


### PR DESCRIPTION
It currently introduces too many fake positives.

I will refactor it in a better way later.