### PR TITLE
fix(prebuilts): fix affine database_url env

### DIFF
--- a/prebuilts/affine.toml
+++ b/prebuilts/affine.toml
@@ -60,7 +60,7 @@ AFFiNE.ENV_MAP = {
     AFFINE_SERVER_HOST: 'host',
     AFFINE_SERVER_SUB_PATH: 'path',
     AFFINE_SERVER_HTTPS: ['https', 'boolean'],
-    DATABASE_URL: 'db.url',
+    DATABASE_URL: 'database.datasourceUrl',
     ENABLE_CAPTCHA: ['auth.captcha.enable', 'boolean'],
     CAPTCHA_TURNSTILE_SECRET: ['auth.captcha.turnstile.secret', 'string'],
     OAUTH_GOOGLE_ENABLED: ['auth.oauthProviders.google.enabled', 'boolean'],


### PR DESCRIPTION
目前部署版本 访问 admin/config 会报错。

![image](https://github.com/user-attachments/assets/b0abc81e-a584-4024-b3b1-501c38c9f5e4)

官方的这个 mapping 已经有变动，或者我们不需要内置这个 mapping。

![image](https://github.com/user-attachments/assets/8a167378-208d-4859-845a-efe24d4526cc)
