### PR TITLE
fix: make logo link locale-aware to prevent wrong locale redirect

### DIFF
--- a/docs/theme.config.js
+++ b/docs/theme.config.js
@@ -1,6 +1,7 @@
 //@ts-check
 
 import React from 'react'
+import Link from 'next/link'
 import { useConfig } from 'nextra-theme-docs'
 import { useRouter } from 'nextra/hooks'
 import WorkingInProgress from './components/WorkingInProgress'
@@ -55,22 +56,26 @@ const config = {
       </>
     ),
   },
-  logo: (
-    <>
-      <img
-        src={LogoBlack.src}
-        style={{ height: 20, objectFit: 'contain' }}
-        alt="zeabur"
-        className="black-logo"
-      />
-      <img
-        src={LogoWhite.src}
-        style={{ height: 20, objectFit: 'contain' }}
-        alt="zeabur"
-        className="white-logo"
-      />
-    </>
-  ),
+  logoLink: false,
+  logo: () => {
+    const { locale } = useRouter()
+    return (
+      <Link href={`/${locale}`}>
+        <img
+          src={LogoBlack.src}
+          style={{ height: 20, objectFit: 'contain' }}
+          alt="zeabur"
+          className="black-logo"
+        />
+        <img
+          src={LogoWhite.src}
+          style={{ height: 20, objectFit: 'contain' }}
+          alt="zeabur"
+          className="white-logo"
+        />
+      </Link>
+    )
+  },
   head: () => {
     const r = useRouter()
     const p = `${r.basePath}${r.pathname}`


### PR DESCRIPTION
The default nextra logo link navigates to "/" which relies on middleware to determine the locale via cookie/Accept-Language. When the cookie is missing, Accept-Language matching can resolve "zh" to "zh-CN" instead of "zh-TW", causing Taiwanese users to be redirected to the wrong locale.

原因： nextra 預設 logo 連結到 "/"，導致瀏覽器導航到 /docs/（無 locale）。接著 middleware 透過 cookie 或 Accept-Language 重導向。台灣用戶的瀏覽器若 Accept-Language 含 zh（無地區碼），@formatjs/intl-localematcher 會將其匹配到 zh-CN 而非 zh-TW。                                                                                                          
                                                                                                                                                                                        
  修改： theme.config.js（兩處變更）                                                                                                                                                    
  1. 新增 logoLink: false — 停用 nextra 預設的 "/" 連結                                                                                                                                 
  2. 將 logo 從靜態 JSX 改為函式元件，用 useRouter() 取得當前 locale，用 Next.js <Link href={/${locale}> 包住 logo 圖片                                                                 
                                                                                                                                                                                        
  這樣點擊 logo 會直接導航到 /docs/zh-TW，完全不經過 middleware 的 locale 推斷邏輯。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated logo configuration to be locale-aware, allowing the logo to respond to language selection changes.
  * Added configuration option to control logo linking behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->