### PR TITLE
docs: add dedicated server volume mount docs across locales

### DIFF
--- a/docs/pages/en-US/server/operate.mdx
+++ b/docs/pages/en-US/server/operate.mdx
@@ -41,13 +41,19 @@ sudo mount /dev/sdb1 /var/lib/rancher/k3s/storage
 
 Replace `/dev/sdb1` with your actual disk partition name.
 
-If you want the disk to remain mounted after a server reboot, you can add the mount entry to `/etc/fstab`:
+If you want the disk to remain mounted after a server reboot, you can add the mount entry to `/etc/fstab`. Using a UUID is recommended over a device path like `/dev/sdb1`, as device names can change across reboots or hardware changes. Use `blkid` to find the UUID:
 
 ```bash
-echo '/dev/sdb1 /var/lib/rancher/k3s/storage ext4 defaults,nofail 0 2' | sudo tee -a /etc/fstab
+sudo blkid /dev/sdb1
 ```
 
-Replace `/dev/sdb1` and `ext4` with your actual disk partition name and filesystem type. After updating `/etc/fstab`, we recommend running the following command to verify the configuration:
+Then add the entry using the UUID:
+
+```bash
+echo 'UUID=<your-partition-uuid> /var/lib/rancher/k3s/storage ext4 defaults,nofail 0 2' | sudo tee -a /etc/fstab
+```
+
+Replace `<your-partition-uuid>` and `ext4` with your actual partition UUID and filesystem type. After updating `/etc/fstab`, we recommend running the following command to verify the configuration:
 
 ```bash
 sudo mount -a
@@ -56,7 +62,7 @@ sudo mount -a
 After the mount is complete, the disk space will be used as shared storage for services on the entire Dedicated Server.
 
 <Callout type="warning">
-    This operation will clear the existing contents of `/var/lib/rancher/k3s/storage` and affect any persistent data currently relying on that path. Make sure to back up the relevant data first, and perform this during a maintenance window or migration to avoid service interruption or data loss.
+    This operation will make the existing contents of `/var/lib/rancher/k3s/storage` inaccessible while the volume is mounted (they are hidden, not deleted, and will reappear if the volume is unmounted). It will also affect any persistent data currently relying on that path. Make sure to back up the relevant data first, and perform this during a maintenance window or migration to avoid service interruption or data loss.
 </Callout>
 
 ## Recovering from OOM (Server Offline)

--- a/docs/pages/en-US/server/operate.mdx
+++ b/docs/pages/en-US/server/operate.mdx
@@ -29,6 +29,36 @@ $ sudo k3s crictl rmi --prune
 
 Sometimes, the logs recorded by K3s for each container can also take up a lot of space. You can try cleaning these logs in the [K3s logs directory](https://docs.k3s.io/faq#where-are-the-k3s-logs).
 
+## Mounting a Volume on a Dedicated Server
+
+If you want to expand persistent storage for a Dedicated Server, you can mount an additional disk to `/var/lib/rancher/k3s/storage` on the server itself. This is a host-level maintenance operation. You can use the **SSH** entry in the left sidebar of the Zeabur server page to enter the server and run the required commands.
+
+For example, you can use the following command to mount an additional disk to `/var/lib/rancher/k3s/storage`:
+
+```bash
+sudo mount /dev/sdb1 /var/lib/rancher/k3s/storage
+```
+
+Replace `/dev/sdb1` with your actual disk partition name.
+
+If you want the disk to remain mounted after a server reboot, you can add the mount entry to `/etc/fstab`:
+
+```bash
+echo '/dev/sdb1 /var/lib/rancher/k3s/storage ext4 defaults,nofail 0 2' | sudo tee -a /etc/fstab
+```
+
+Replace `/dev/sdb1` and `ext4` with your actual disk partition name and filesystem type. After updating `/etc/fstab`, we recommend running the following command to verify the configuration:
+
+```bash
+sudo mount -a
+```
+
+After the mount is complete, the disk space will be used as shared storage for services on the entire Dedicated Server.
+
+<Callout type="warning">
+    This operation will clear the existing contents of `/var/lib/rancher/k3s/storage` and affect any persistent data currently relying on that path. Make sure to back up the relevant data first, and perform this during a maintenance window or migration to avoid service interruption or data loss.
+</Callout>
+
 ## Recovering from OOM (Server Offline)
 
 If your server runs out of memory (OOM), the K3s status indicator on the server dashboard may turn red, meaning Kubernetes is no longer running properly. When this happens, your services will become unreachable.

--- a/docs/pages/es-ES/server/operate.mdx
+++ b/docs/pages/es-ES/server/operate.mdx
@@ -29,6 +29,36 @@ $ sudo k3s crictl rmi --prune
 
 A veces, los registros guardados por K3s para cada contenedor también pueden ocupar mucho espacio. Puedes intentar limpiar estos registros en el [directorio de registros de K3s](https://docs.k3s.io/faq#where-are-the-k3s-logs).
 
+## Montar un disco en un Dedicated Server
+
+Si quieres ampliar el almacenamiento persistente de un Dedicated Server, puedes montar un disco adicional en `/var/lib/rancher/k3s/storage` directamente en el servidor. Esta es una operación de mantenimiento a nivel del host. Puedes usar la función **SSH** en la barra lateral izquierda de la página del servidor en Zeabur para entrar al servidor y ejecutar los comandos necesarios.
+
+Por ejemplo, puedes usar el siguiente comando para montar un disco adicional en `/var/lib/rancher/k3s/storage`:
+
+```bash
+sudo mount /dev/sdb1 /var/lib/rancher/k3s/storage
+```
+
+Sustituye `/dev/sdb1` por el nombre real de la partición del disco.
+
+Si quieres que el disco siga montado después de reiniciar el servidor, puedes añadir la configuración a `/etc/fstab`:
+
+```bash
+echo '/dev/sdb1 /var/lib/rancher/k3s/storage ext4 defaults,nofail 0 2' | sudo tee -a /etc/fstab
+```
+
+Sustituye `/dev/sdb1` y `ext4` por el nombre real de la partición del disco y el tipo de sistema de archivos. Después de actualizar `/etc/fstab`, recomendamos ejecutar el siguiente comando para verificar que la configuración sea correcta:
+
+```bash
+sudo mount -a
+```
+
+Una vez completado el montaje, el espacio de este disco se usará como almacenamiento compartido para los servicios de todo el Dedicated Server.
+
+<Callout type="warning">
+    Esta operación vaciará el contenido actual de `/var/lib/rancher/k3s/storage` y afectará a cualquier dato persistente que dependa de esa ruta. Asegúrate de hacer una copia de seguridad de los datos relevantes primero y realiza esta operación durante una ventana de mantenimiento o migración para evitar interrupciones del servicio o pérdida de datos.
+</Callout>
+
 ## Recuperación de OOM (Servidor Fuera de Línea)
 
 Si tu servidor se queda sin memoria (OOM), el indicador de estado de K3s en el panel del servidor puede volverse rojo, lo que significa que Kubernetes ya no está funcionando correctamente. Cuando esto sucede, tus servicios serán inaccesibles.

--- a/docs/pages/es-ES/server/operate.mdx
+++ b/docs/pages/es-ES/server/operate.mdx
@@ -41,13 +41,19 @@ sudo mount /dev/sdb1 /var/lib/rancher/k3s/storage
 
 Sustituye `/dev/sdb1` por el nombre real de la partición del disco.
 
-Si quieres que el disco siga montado después de reiniciar el servidor, puedes añadir la configuración a `/etc/fstab`:
+Si quieres que el disco siga montado después de reiniciar el servidor, puedes añadir la configuración a `/etc/fstab`. Se recomienda usar UUID en lugar de rutas de dispositivo como `/dev/sdb1`, ya que los nombres de dispositivo pueden cambiar tras reinicios o cambios de hardware. Usa `blkid` para obtener el UUID:
 
 ```bash
-echo '/dev/sdb1 /var/lib/rancher/k3s/storage ext4 defaults,nofail 0 2' | sudo tee -a /etc/fstab
+sudo blkid /dev/sdb1
 ```
 
-Sustituye `/dev/sdb1` y `ext4` por el nombre real de la partición del disco y el tipo de sistema de archivos. Después de actualizar `/etc/fstab`, recomendamos ejecutar el siguiente comando para verificar que la configuración sea correcta:
+Luego añade la entrada usando el UUID:
+
+```bash
+echo 'UUID=<your-partition-uuid> /var/lib/rancher/k3s/storage ext4 defaults,nofail 0 2' | sudo tee -a /etc/fstab
+```
+
+Sustituye `<your-partition-uuid>` y `ext4` por el UUID real de la partición y el tipo de sistema de archivos. Después de actualizar `/etc/fstab`, recomendamos ejecutar el siguiente comando para verificar que la configuración sea correcta:
 
 ```bash
 sudo mount -a
@@ -56,7 +62,7 @@ sudo mount -a
 Una vez completado el montaje, el espacio de este disco se usará como almacenamiento compartido para los servicios de todo el Dedicated Server.
 
 <Callout type="warning">
-    Esta operación vaciará el contenido actual de `/var/lib/rancher/k3s/storage` y afectará a cualquier dato persistente que dependa de esa ruta. Asegúrate de hacer una copia de seguridad de los datos relevantes primero y realiza esta operación durante una ventana de mantenimiento o migración para evitar interrupciones del servicio o pérdida de datos.
+    Esta operación hará que el contenido actual de `/var/lib/rancher/k3s/storage` quede inaccesible mientras el volumen esté montado (el contenido se oculta, no se elimina, y volverá a ser visible si se desmonta el volumen). También afectará a cualquier dato persistente que dependa de esa ruta. Asegúrate de hacer una copia de seguridad de los datos relevantes primero y realiza esta operación durante una ventana de mantenimiento o migración para evitar interrupciones del servicio o pérdida de datos.
 </Callout>
 
 ## Recuperación de OOM (Servidor Fuera de Línea)

--- a/docs/pages/ja-JP/server/operate.mdx
+++ b/docs/pages/ja-JP/server/operate.mdx
@@ -41,13 +41,19 @@ sudo mount /dev/sdb1 /var/lib/rancher/k3s/storage
 
 `/dev/sdb1` は実際のディスクパーティション名に置き換えてください。
 
-サーバー再起動後も自動的にマウントしたい場合は、マウント情報を `/etc/fstab` に追加できます。
+サーバー再起動後も自動的にマウントしたい場合は、マウント情報を `/etc/fstab` に追加できます。デバイスパス（`/dev/sdb1` など）は再起動やハードウェア変更時に変わる可能性があるため、UUID を使用することを推奨します。`blkid` で UUID を確認してください。
 
 ```bash
-echo '/dev/sdb1 /var/lib/rancher/k3s/storage ext4 defaults,nofail 0 2' | sudo tee -a /etc/fstab
+sudo blkid /dev/sdb1
 ```
 
-`/dev/sdb1` と `ext4` は、実際のディスクパーティション名とファイルシステムの種類に置き換えてください。追記後は、`/etc/fstab` の設定が正しいことを確認するため、次のコマンドを実行することをおすすめします。
+UUID を使ってマウントエントリを追加します。
+
+```bash
+echo 'UUID=<your-partition-uuid> /var/lib/rancher/k3s/storage ext4 defaults,nofail 0 2' | sudo tee -a /etc/fstab
+```
+
+`<your-partition-uuid>` と `ext4` は、実際のパーティション UUID とファイルシステムの種類に置き換えてください。追記後は、`/etc/fstab` の設定が正しいことを確認するため、次のコマンドを実行することをおすすめします。
 
 ```bash
 sudo mount -a
@@ -56,7 +62,7 @@ sudo mount -a
 マウントが完了すると、このディスクの容量は Dedicated Server 全体の共有ストレージとして使用され、サーバー上の各サービスから利用されます。
 
 <Callout type="warning">
-    この操作を行うと、`/var/lib/rancher/k3s/storage` の既存内容は消去され、このパスに依存している永続データにも影響します。必ず事前に関連データをバックアップし、サービス停止や移行のメンテナンス時間帯に実施して、サービス中断やデータ損失を防いでください。
+    この操作を行うと、`/var/lib/rancher/k3s/storage` の既存内容はマウント中に見えなくなります（内容は削除されるのではなく隠されるだけで、アンマウント後は再び表示されます）。このパスに依存している永続データにも影響します。必ず事前に関連データをバックアップし、サービス停止や移行のメンテナンス時間帯に実施して、サービス中断やデータ損失を防いでください。
 </Callout>
 
 ## OOMからの復旧（サーバーオフライン）

--- a/docs/pages/ja-JP/server/operate.mdx
+++ b/docs/pages/ja-JP/server/operate.mdx
@@ -29,6 +29,36 @@ $ sudo k3s crictl rmi --prune
 
 K3sが各コンテナに対して記録しているログも、かなりの容量を占めることがあります。[K3sのlogsディレクトリ](https://docs.k3s.io/faq#where-are-the-k3s-logs)でこれらのログを清掃することができます。
 
+## Dedicated Server でディスクをマウントする
+
+Dedicated Server の永続ストレージを拡張したい場合は、追加のディスクをサーバー上で `/var/lib/rancher/k3s/storage` にマウントできます。これはホストレベルのメンテナンス作業です。Zeabur のサーバーページ左側にある **SSH** 機能を使ってサーバーに入り、必要なコマンドを実行してください。
+
+たとえば、追加ディスクを `/var/lib/rancher/k3s/storage` にマウントするには、次のコマンドを使用できます。
+
+```bash
+sudo mount /dev/sdb1 /var/lib/rancher/k3s/storage
+```
+
+`/dev/sdb1` は実際のディスクパーティション名に置き換えてください。
+
+サーバー再起動後も自動的にマウントしたい場合は、マウント情報を `/etc/fstab` に追加できます。
+
+```bash
+echo '/dev/sdb1 /var/lib/rancher/k3s/storage ext4 defaults,nofail 0 2' | sudo tee -a /etc/fstab
+```
+
+`/dev/sdb1` と `ext4` は、実際のディスクパーティション名とファイルシステムの種類に置き換えてください。追記後は、`/etc/fstab` の設定が正しいことを確認するため、次のコマンドを実行することをおすすめします。
+
+```bash
+sudo mount -a
+```
+
+マウントが完了すると、このディスクの容量は Dedicated Server 全体の共有ストレージとして使用され、サーバー上の各サービスから利用されます。
+
+<Callout type="warning">
+    この操作を行うと、`/var/lib/rancher/k3s/storage` の既存内容は消去され、このパスに依存している永続データにも影響します。必ず事前に関連データをバックアップし、サービス停止や移行のメンテナンス時間帯に実施して、サービス中断やデータ損失を防いでください。
+</Callout>
+
 ## OOMからの復旧（サーバーオフライン）
 
 サーバーのメモリが不足（OOM）すると、サーバーダッシュボードのK3sステータスインジケーターが赤色に変わり、Kubernetesが正常に動作していないことを示します。この場合、サービスにアクセスできなくなります。

--- a/docs/pages/zh-CN/server/operate.mdx
+++ b/docs/pages/zh-CN/server/operate.mdx
@@ -29,6 +29,36 @@ $ sudo k3s crictl rmi --prune
 
 有时候 K3s 针对每个容器记录的 Logs 也会占用不少空间，您可以试着到 [K3s 的 logs 目录](https://docs.k3s.io/faq#where-are-the-k3s-logs) 清理这些 Logs。
 
+## 挂载硬盘到 Dedicated Server
+
+如果您想为 Dedicated Server 扩充持久存储空间，可以在服务器系统上将一块额外硬盘挂载到 `/var/lib/rancher/k3s/storage`。这是主机层级的维护操作，您可以使用 Zeabur 服务器页面左侧的 **SSH** 功能进入服务器后执行相关指令。
+
+例如，您可以使用以下指令将额外硬盘挂载到 `/var/lib/rancher/k3s/storage`：
+
+```bash
+sudo mount /dev/sdb1 /var/lib/rancher/k3s/storage
+```
+
+请将 `/dev/sdb1` 替换成您的实际磁盘分区名称。
+
+如果您希望服务器重启后仍然自动挂载这块硬盘，可以将挂载信息写入 `/etc/fstab`：
+
+```bash
+echo '/dev/sdb1 /var/lib/rancher/k3s/storage ext4 defaults,nofail 0 2' | sudo tee -a /etc/fstab
+```
+
+请将 `/dev/sdb1` 和 `ext4` 替换为您的实际磁盘分区名称与文件系统类型。写入后，建议执行以下指令确认 `/etc/fstab` 配置正确：
+
+```bash
+sudo mount -a
+```
+
+挂载完成后，这块硬盘上的空间会作为整台 Dedicated Server 的共享存储空间，供服务器上的服务共同使用。
+
+<Callout type="warning">
+    这个操作会清空 `/var/lib/rancher/k3s/storage` 现有内容，并影响原本依赖该路径的持久数据。请务必先备份相关数据，并在停机或迁移维护时段内操作，以免造成服务中断或数据丢失。
+</Callout>
+
 ## 从 OOM 恢复（服务器离线）
 
 当服务器内存不足（OOM）时，服务器仪表盘上的 K3s 状态指示灯可能会变红，表示 Kubernetes 已无法正常运行。此时您的服务将无法访问。

--- a/docs/pages/zh-CN/server/operate.mdx
+++ b/docs/pages/zh-CN/server/operate.mdx
@@ -41,13 +41,19 @@ sudo mount /dev/sdb1 /var/lib/rancher/k3s/storage
 
 请将 `/dev/sdb1` 替换成您的实际磁盘分区名称。
 
-如果您希望服务器重启后仍然自动挂载这块硬盘，可以将挂载信息写入 `/etc/fstab`：
+如果您希望服务器重启后仍然自动挂载这块硬盘，可以将挂载信息写入 `/etc/fstab`。建议使用 UUID 而非设备路径（如 `/dev/sdb1`），因为设备名称可能在重启或硬件变更后发生改变。使用 `blkid` 获取 UUID：
 
 ```bash
-echo '/dev/sdb1 /var/lib/rancher/k3s/storage ext4 defaults,nofail 0 2' | sudo tee -a /etc/fstab
+sudo blkid /dev/sdb1
 ```
 
-请将 `/dev/sdb1` 和 `ext4` 替换为您的实际磁盘分区名称与文件系统类型。写入后，建议执行以下指令确认 `/etc/fstab` 配置正确：
+然后使用 UUID 添加挂载条目：
+
+```bash
+echo 'UUID=<your-partition-uuid> /var/lib/rancher/k3s/storage ext4 defaults,nofail 0 2' | sudo tee -a /etc/fstab
+```
+
+请将 `<your-partition-uuid>` 和 `ext4` 替换为您的实际分区 UUID 与文件系统类型。写入后，建议执行以下指令确认 `/etc/fstab` 配置正确：
 
 ```bash
 sudo mount -a
@@ -56,7 +62,7 @@ sudo mount -a
 挂载完成后，这块硬盘上的空间会作为整台 Dedicated Server 的共享存储空间，供服务器上的服务共同使用。
 
 <Callout type="warning">
-    这个操作会清空 `/var/lib/rancher/k3s/storage` 现有内容，并影响原本依赖该路径的持久数据。请务必先备份相关数据，并在停机或迁移维护时段内操作，以免造成服务中断或数据丢失。
+    这个操作会使 `/var/lib/rancher/k3s/storage` 的现有内容在挂载期间不可见（内容被遮蔽而非删除，卸载后将重新可见），并影响原本依赖该路径的持久数据。请务必先备份相关数据，并在停机或迁移维护时段内操作，以免造成服务中断或数据丢失。
 </Callout>
 
 ## 从 OOM 恢复（服务器离线）

--- a/docs/pages/zh-TW/server/operate.mdx
+++ b/docs/pages/zh-TW/server/operate.mdx
@@ -41,13 +41,19 @@ sudo mount /dev/sdb1 /var/lib/rancher/k3s/storage
 
 請將 `/dev/sdb1` 替換成您的實際磁碟分割區名稱。
 
-如果您希望伺服器重新啟動後仍然自動掛載這顆硬碟，可以將掛載資訊寫入 `/etc/fstab`：
+如果您希望伺服器重新啟動後仍然自動掛載這顆硬碟，可以將掛載資訊寫入 `/etc/fstab`。建議使用 UUID 而非裝置路徑（如 `/dev/sdb1`），因為裝置名稱可能在重新啟動或硬體變更後改變。使用 `blkid` 取得 UUID：
 
 ```bash
-echo '/dev/sdb1 /var/lib/rancher/k3s/storage ext4 defaults,nofail 0 2' | sudo tee -a /etc/fstab
+sudo blkid /dev/sdb1
 ```
 
-請將 `/dev/sdb1` 和 `ext4` 替換為您的實際磁碟分割區名稱與檔案系統類型。寫入後，建議執行以下指令確認 `/etc/fstab` 設定正確：
+然後使用 UUID 新增掛載條目：
+
+```bash
+echo 'UUID=<your-partition-uuid> /var/lib/rancher/k3s/storage ext4 defaults,nofail 0 2' | sudo tee -a /etc/fstab
+```
+
+請將 `<your-partition-uuid>` 和 `ext4` 替換為您的實際分割區 UUID 與檔案系統類型。寫入後，建議執行以下指令確認 `/etc/fstab` 設定正確：
 
 ```bash
 sudo mount -a
@@ -56,7 +62,7 @@ sudo mount -a
 掛載完成後，這顆硬碟上的空間會作為整台 Dedicated Server 的共享儲存空間，供伺服器上的服務共同使用。
 
 <Callout type="warning">
-    這個操作會清空 `/var/lib/rancher/k3s/storage` 現有內容，並影響原本依賴該路徑的持久資料。請務必先備份相關資料，並在停機或遷移維護時段內操作，以免造成服務中斷或資料遺失。
+    這個操作會使 `/var/lib/rancher/k3s/storage` 的現有內容在掛載期間不可見（內容被遮蔽而非刪除，卸載後將重新可見），並影響原本依賴該路徑的持久資料。請務必先備份相關資料，並在停機或遷移維護時段內操作，以免造成服務中斷或資料遺失。
 </Callout>
 
 ## 從 OOM 恢復（伺服器離線）

--- a/docs/pages/zh-TW/server/operate.mdx
+++ b/docs/pages/zh-TW/server/operate.mdx
@@ -29,6 +29,36 @@ $ sudo k3s crictl rmi --prune
 
 有時候 K3s 針對每個容器記錄的 Logs 也會佔用不少空間，您可以試著到 [K3s 的 logs 目錄](https://docs.k3s.io/faq#where-are-the-k3s-logs) 清理這些 Logs。
 
+## 在 Dedicated Server 掛載硬碟
+
+如果您想為 Dedicated Server 擴充持久儲存空間，可以在伺服器系統上將一顆額外硬碟掛載到 `/var/lib/rancher/k3s/storage`。這是主機層級的維護操作，您可以使用 Zeabur 伺服器頁面左側的 **SSH** 功能進入伺服器後執行相關指令。
+
+例如，您可以使用以下指令將額外硬碟掛載到 `/var/lib/rancher/k3s/storage`：
+
+```bash
+sudo mount /dev/sdb1 /var/lib/rancher/k3s/storage
+```
+
+請將 `/dev/sdb1` 替換成您的實際磁碟分割區名稱。
+
+如果您希望伺服器重新啟動後仍然自動掛載這顆硬碟，可以將掛載資訊寫入 `/etc/fstab`：
+
+```bash
+echo '/dev/sdb1 /var/lib/rancher/k3s/storage ext4 defaults,nofail 0 2' | sudo tee -a /etc/fstab
+```
+
+請將 `/dev/sdb1` 和 `ext4` 替換為您的實際磁碟分割區名稱與檔案系統類型。寫入後，建議執行以下指令確認 `/etc/fstab` 設定正確：
+
+```bash
+sudo mount -a
+```
+
+掛載完成後，這顆硬碟上的空間會作為整台 Dedicated Server 的共享儲存空間，供伺服器上的服務共同使用。
+
+<Callout type="warning">
+    這個操作會清空 `/var/lib/rancher/k3s/storage` 現有內容，並影響原本依賴該路徑的持久資料。請務必先備份相關資料，並在停機或遷移維護時段內操作，以免造成服務中斷或資料遺失。
+</Callout>
+
 ## 從 OOM 恢復（伺服器離線）
 
 當伺服器記憶體不足（OOM）時，伺服器儀表板上的 K3s 狀態指示燈可能會變紅，表示 Kubernetes 已無法正常運作。此時您的服務將無法存取。
@@ -190,4 +220,3 @@ $ kubectl exec -it <Pod 名稱> -n <Namespace> -- /bin/sh
 ```bash
 $ /usr/local/bin/k3s-uninstall.sh
 ```
-


### PR DESCRIPTION
Fixed PLA-145


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added multilingual guides (en, es, ja, zh-CN, zh-TW) for mounting additional storage on dedicated servers: steps for immediate mount, persisting mounts via UUID entries in /etc/fstab, and validating with mount -a. Includes warning about mounted volumes hiding existing contents and possible impact to persistent data; recommends backups and maintenance windows. Minor trailing-whitespace cleanup in one translation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->