### PR TITLE
docs: update README to match what Zeabur currently is

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,7 @@ Zeabur is built for AI-centric workflows — deploy and operate your infrastruct
 - **[Claude Code Plugin](https://zeabur.com/docs/developer/claude-code-skills)** — Zeabur's official Claude Code plugin converts natural language into infrastructure operations. Rent servers, deploy services, bind domains, manage databases, and debug issues — all without leaving your editor.
   ```bash
   claude plugin marketplace add zeabur/zeabur-claude-plugin
+  claude plugin install zeabur@zeabur
   ```
 - **[MCP Server](https://zeabur.com/docs/mcp)** — Connect Zeabur to any MCP-compatible AI assistant (Claude Desktop, Cursor, etc.) to manage projects, deployments, environment variables, and logs through conversation.
 - **[VS Code / Cursor Extension](https://marketplace.visualstudio.com/items?itemName=Zeabur.zeabur-vscode)** — Deploy your local project to Zeabur in one click without leaving your editor.

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ Zeabur handles all your deployment work so you can focus on your code.
 
 Tell your AI agent what you need — Zeabur deploys services, rents servers, manages domains, configures databases, and troubleshoots issues, all through natural language. No DevOps expertise required.
 
-<a href="https://www.producthunt.com/posts/zeabur?utm_source=badge-top-post-badge&utm_medium=badge&utm_souce=badge-zeabur" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=404816&theme=light&period=daily" alt="Zeabur - Deploy&#0032;painlessly&#0032;and&#0032;scale&#0032;infinitely&#0032;with&#0032;just&#0032;one&#0032;click | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
+<a href="https://www.producthunt.com/posts/zeabur?utm_source=badge-top-post-badge&utm_medium=badge&utm_source=badge-zeabur" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=404816&theme=light&period=daily" alt="Zeabur - Deploy&#0032;painlessly&#0032;and&#0032;scale&#0032;infinitely&#0032;with&#0032;just&#0032;one&#0032;click | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
 
 ## Features
 

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ Zeabur handles all your deployment work so you can focus on your code.
 
 Tell your AI agent what you need — Zeabur deploys services, rents servers, manages domains, configures databases, and troubleshoots issues, all through natural language. No DevOps expertise required.
 
-<a href="https://www.producthunt.com/posts/zeabur?utm_source=badge-top-post-badge&utm_medium=badge&utm_source=badge-zeabur" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=404816&theme=light&period=daily" alt="Zeabur - Deploy&#0032;painlessly&#0032;and&#0032;scale&#0032;infinitely&#0032;with&#0032;just&#0032;one&#0032;click | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
+<a href="https://www.producthunt.com/posts/zeabur?utm_source=badge-top-post-badge&utm_medium=badge&utm_campaign=badge-zeabur" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=404816&theme=light&period=daily" alt="Zeabur - Deploy&#0032;painlessly&#0032;and&#0032;scale&#0032;infinitely&#0032;with&#0032;just&#0032;one&#0032;click | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
 
 ## Features
 
@@ -71,7 +71,7 @@ Zeabur provides full [domain management](https://zeabur.com/docs/domain) capabil
 
 ### Email
 
-[Zeabur Email](https://zeabur.com/docs/email) is an enterprise-grade email sending API service built on AWS SES with a 99.9% uptime guarantee.
+[Zeabur Email](https://zeabur.com/docs/email) is an enterprise-grade email-sending API service built on AWS SES with a 99.9% uptime guarantee.
 
 - Simple REST API for instant, scheduled, and batch sending.
 - Webhook notifications for delivery, bounce, and complaint events.

--- a/readme.md
+++ b/readme.md
@@ -93,7 +93,7 @@ Zeabur offers a rich catalog of [one-click deployment templates](https://zeabur.
 
 - **[Community Forum](https://zeabur.com/forum)** — Official support hub for questions, issues, and discussions. Priority response times for paid plans.
 - **[Discord](https://discord.gg/DrdGCvXEyY)** — Chat with the Zeabur community.
-- **[GitHub Discussions](https://github.com/orgs/zeabur/discussions)** — Feature requests and community discussions.
+
 
 ## Documentation
 

--- a/readme.md
+++ b/readme.md
@@ -22,12 +22,13 @@ Zeabur automatically analyzes your code to detect its language and framework —
 
 Push to your repository and Zeabur builds, deploys, and updates your service automatically. It supports GitHub integration, Dockerfile, Docker images, CLI, a Chrome extension, and more.
 
-### Servers
+### Servers & Clusters
 
-Beyond shared clusters, you can [register your own server](https://zeabur.com/docs/server) with Zeabur and let the platform manage deployments, firewall rules, and resource allocation on your hardware — no SSH required.
+Zeabur supports two infrastructure options:
 
-- **Buy a server** from Zeabur at competitive pricing, or **bring your own hardware** from AWS, GCP, Hetzner, or your own datacenter.
-- Servers are billed monthly at a fixed rate and are ideal for production workloads with stable requirements.
+- **[Servers](https://zeabur.com/docs/server)** — Single-machine deployments. Buy a server from Zeabur or bring your own hardware (AWS, GCP, Hetzner, your own datacenter). Zeabur manages deployments, firewall rules, and resource allocation — no SSH required. Billed monthly at a fixed rate; ideal for small-to-medium workloads and stable production services.
+
+- **[Clusters](https://zeabur.com/docs/cluster)** — Multi-node Kubernetes environments for high-availability workloads. Get cross-node scheduling, automatic failover, distributed storage, and horizontal scaling. Purchase a cluster from Zeabur or connect your own existing Kubernetes cluster.
 
 ### Wonder Mesh (Beta)
 

--- a/readme.md
+++ b/readme.md
@@ -8,9 +8,11 @@
 
 <br/>
 
-## Intro
+## Your AI DevOps Engineer
 
-Zeabur is an AI-centric deployment platform — build with AI agents, deploy with AI tools, and run AI models, all in one place.
+Zeabur handles all your deployment work so you can focus on your code.
+
+Tell your AI agent what you need — Zeabur deploys services, rents servers, manages domains, configures databases, and troubleshoots issues, all through natural language. No DevOps expertise required.
 
 <a href="https://www.producthunt.com/posts/zeabur?utm_source=badge-top-post-badge&utm_medium=badge&utm_souce=badge-zeabur" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=404816&theme=light&period=daily" alt="Zeabur - Deploy&#0032;painlessly&#0032;and&#0032;scale&#0032;infinitely&#0032;with&#0032;just&#0032;one&#0032;click | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
 

--- a/readme.md
+++ b/readme.md
@@ -101,10 +101,10 @@ For full details, visit [zeabur.com/docs](https://zeabur.com/docs).
 
 ## Contributing
 
-### Dashboard Localization
+Contributions of all kinds are welcome:
 
-Help translate the Zeabur dashboard and earn credits through the [Contribution Reward Program](https://zeabur.com/docs/rewards/contribution). Contact us on [Discord](https://zeabur.com/dc) or the [forum](https://zeabur.com/forum) to get started.
+- **Docs** — Fix errors, improve clarity, or add examples by opening a pull request in this repository.
+- **Templates** — Publish a template to the [marketplace](https://zeabur.com/templates) and earn rewards. See the [template format guide](https://zeabur.com/docs/template/template-format) to get started.
+- **OSS projects** — Browse our open-source repositories under the [zeabur](https://github.com/zeabur) GitHub organization and open issues or pull requests.
 
-### Templates
-
-Publish a template to the [template marketplace](https://zeabur.com/templates) and earn rewards. See the [template format guide](https://zeabur.com/docs/template/template-format) to get started.
+Not sure where to start? Join the [forum](https://zeabur.com/forum) or [Discord](https://discord.gg/DrdGCvXEyY) and let us know what you'd like to work on.

--- a/readme.md
+++ b/readme.md
@@ -10,11 +10,24 @@
 
 ## Intro
 
-Zeabur is a platform that helps developers deploy their services with one click — no matter what programming language or framework is used.
+Zeabur is an AI-centric deployment platform — build with AI agents, deploy with AI tools, and run AI models, all in one place.
 
 <a href="https://www.producthunt.com/posts/zeabur?utm_source=badge-top-post-badge&utm_medium=badge&utm_souce=badge-zeabur" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=404816&theme=light&period=daily" alt="Zeabur - Deploy&#0032;painlessly&#0032;and&#0032;scale&#0032;infinitely&#0032;with&#0032;just&#0032;one&#0032;click | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
 
 ## Features
+
+### AI-Native Development
+
+Zeabur is built for AI-centric workflows — deploy and operate your infrastructure directly from your AI tools.
+
+- **[Claude Code Plugin](https://zeabur.com/docs/developer/claude-code-skills)** — Zeabur's official Claude Code plugin converts natural language into infrastructure operations. Rent servers, deploy services, bind domains, manage databases, and debug issues — all without leaving your editor.
+  ```bash
+  claude plugin marketplace add zeabur/zeabur-claude-plugin
+  ```
+- **[MCP Server](https://zeabur.com/docs/mcp)** — Connect Zeabur to any MCP-compatible AI assistant (Claude Desktop, Cursor, etc.) to manage projects, deployments, environment variables, and logs through conversation.
+- **[VS Code / Cursor Extension](https://marketplace.visualstudio.com/items?itemName=Zeabur.zeabur-vscode)** — Deploy your local project to Zeabur in one click without leaving your editor.
+- **[AI Hub](https://zeabur.com/docs/ai-hub)** — Access GPT-4o, Claude, Grok, and more through a single OpenAI-compatible API key, with per-token billing and multi-region endpoints (Tokyo, San Francisco).
+- **[InsForge](https://zeabur.com/docs/integrations)** — An agent-native Supabase alternative with PostgreSQL, JWT auth, S3-compatible storage, serverless edge functions, and MCP support — purpose-built for AI agents building full-stack apps autonomously.
 
 ### One-Click Deployment
 
@@ -37,14 +50,6 @@ Zeabur supports two infrastructure options:
 - Works from home labs, offices, or any network environment.
 - Deploy templates, push code, bind domains, and monitor resources just like any managed server.
 - Supports Linux (amd64/arm64) and macOS (amd64/arm64).
-
-### AI Hub
-
-[AI Hub](https://zeabur.com/docs/ai-hub) is a unified AI service platform giving you access to multiple AI models (OpenAI GPT, Anthropic Claude, xAI Grok, and more) through a single API key.
-
-- Compatible with the OpenAI API format — drop it into existing applications with minimal changes.
-- Transparent pay-as-you-go billing per token with full usage history.
-- Multi-region endpoints (Tokyo, San Francisco) for optimal latency.
 
 ### Domain
 
@@ -69,24 +74,11 @@ Zeabur offers a rich catalog of [one-click deployment templates](https://zeabur.
 - Each template pre-wires services, environment variables, and connection settings automatically.
 - Create and share your own templates via YAML.
 
-### Integrations
-
-Zeabur provides [built-in integrations](https://zeabur.com/docs/integrations) with third-party services so you can add powerful backend capabilities to your project without separate deployments.
-
-- **InsForge** — An agent-native Supabase alternative with PostgreSQL, JWT auth, S3-compatible storage, serverless edge functions, and MCP protocol support for AI IDE integration.
-
 ### Powerful Configuration
 
 - Environment variables managed from the dashboard — no `.env` files required.
-- Multiple environment support (`production`, `staging`, `development`, etc.) with separate domains and branches.
 - Rollback, suspend, restart, and scale services with one click.
 - Invite team members to collaborate on the same project.
-
-### Pay as You Go
-
-Zeabur uses a consumption-based pricing model — you only pay for the resources your services actually use, billed by the minute.
-
-See the [pricing page](https://zeabur.com/docs/pricing) for details.
 
 ### Developer Tools
 

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,6 @@ Zeabur is built for AI-centric workflows — deploy and operate your infrastruct
   ```
 - **[MCP Server](https://zeabur.com/docs/mcp)** — Connect Zeabur to any MCP-compatible AI assistant (Claude Desktop, Cursor, etc.) to manage projects, deployments, environment variables, and logs through conversation.
 - **[VS Code / Cursor Extension](https://marketplace.visualstudio.com/items?itemName=Zeabur.zeabur-vscode)** — Deploy your local project to Zeabur in one click without leaving your editor.
-- **[AI Hub](https://zeabur.com/docs/ai-hub)** — Access GPT-4o, Claude, Grok, and more through a single OpenAI-compatible API key, with per-token billing and multi-region endpoints (Tokyo, San Francisco).
 - **[InsForge](https://zeabur.com/docs/integrations)** — An agent-native Supabase alternative with PostgreSQL, JWT auth, S3-compatible storage, serverless edge functions, and MCP support — purpose-built for AI agents building full-stack apps autonomously.
 
 ### One-Click Deployment
@@ -45,7 +44,15 @@ Zeabur supports two infrastructure options:
 
 - **[Clusters](https://zeabur.com/docs/cluster)** — Multi-node Kubernetes environments for high-availability workloads. Get cross-node scheduling, automatic failover, distributed storage, and horizontal scaling. Purchase a cluster from Zeabur or connect your own existing Kubernetes cluster.
 
-### Wonder Mesh (Beta)
+### AI Hub
+
+[AI Hub](https://zeabur.com/docs/ai-hub) is a unified AI service platform giving you access to multiple AI models through a single OpenAI-compatible API key.
+
+- Supports GPT-5, Claude, Grok, and more — no separate API key per provider.
+- Per-token billing with full usage history.
+- Multi-region endpoints (Tokyo, San Francisco) for optimal latency.
+
+### Wonder Mesh
 
 [Wonder Mesh](https://zeabur.com/docs/wonder-mesh) turns any computer or server into a Zeabur compute node using an encrypted WireGuard tunnel — no public IP, no port forwarding, no firewall changes needed.
 

--- a/readme.md
+++ b/readme.md
@@ -1,59 +1,115 @@
 <p align="center">
-  <a href="https://zeabur.com"><strong>Home</strong></a>
-  <a href="https://zeabur.com/docs"><strong>Documentation</strong></a>
+  <a href="https://zeabur.com"><strong>Home</strong></a> ·
+  <a href="https://zeabur.com/docs"><strong>Documentation</strong></a> ·
+  <a href="https://zeabur.com/templates"><strong>Templates</strong></a> ·
+  <a href="https://zeabur.com/forum"><strong>Forum</strong></a> ·
   <a href="https://discord.gg/DrdGCvXEyY"><strong>Discord</strong></a>
-  <a href="https://github.com/orgs/zeabur/discussions"><strong>Discussion</strong></a>
 </p>
 
 <br/>
 
 ## Intro
 
-Zeabur is a platform that help developers deploy their services with one click.
-
-No matter what programming language or framework is used.
+Zeabur is a platform that helps developers deploy their services with one click — no matter what programming language or framework is used.
 
 <a href="https://www.producthunt.com/posts/zeabur?utm_source=badge-top-post-badge&utm_medium=badge&utm_souce=badge-zeabur" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=404816&theme=light&period=daily" alt="Zeabur - Deploy&#0032;painlessly&#0032;and&#0032;scale&#0032;infinitely&#0032;with&#0032;just&#0032;one&#0032;click | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
 
 ## Features
 
-### One click deployment
+### One-Click Deployment
 
-Zeabur can automatically analyze the code to determine what language and framework the project uses. No more dockerfile or docker-compose.yml!
+Zeabur automatically analyzes your code to detect its language and framework — no Dockerfile or docker-compose.yml required.
 
-All you need to do is to push your code to the repository, and Zeabur will automatically deploy and update your services.
+Push to your repository and Zeabur builds, deploys, and updates your service automatically. It supports GitHub integration, Dockerfile, Docker images, CLI, a Chrome extension, and more.
 
-### Powerful configuration
+### Servers
 
-Zeabur provides a powerful configuration system, which allows you to easily configure your services.
+Beyond shared clusters, you can [register your own server](https://zeabur.com/docs/server) with Zeabur and let the platform manage deployments, firewall rules, and resource allocation on your hardware — no SSH required.
 
-- Configure your environment variables easily, without `.env` files.
-- Add domains for your services with one click. You can use your own domain or just use a subdomain of `zeabur.app`.
-- Multiple environment support, such as `production`, `staging`, `development`, and so on. Bind different domains and branches to different environments to get a separate environment easily.
+- **Buy a server** from Zeabur at competitive pricing, or **bring your own hardware** from AWS, GCP, Hetzner, or your own datacenter.
+- Servers are billed monthly at a fixed rate and are ideal for production workloads with stable requirements.
 
-### Pay as you go
+### Wonder Mesh (Beta)
 
-Are you still 'renting a server'? Zeabur uses a pay-as-you-go model, so you only pay for the resources your service actually uses, and you don't pay for what you don't use!
+[Wonder Mesh](https://zeabur.com/docs/wonder-mesh) turns any computer or server into a Zeabur compute node using an encrypted WireGuard tunnel — no public IP, no port forwarding, no firewall changes needed.
 
-### Integration
+- Works from home labs, offices, or any network environment.
+- Deploy templates, push code, bind domains, and monitor resources just like any managed server.
+- Supports Linux (amd64/arm64) and macOS (amd64/arm64).
 
-Your powerful system needs many different services to work together, such as MySQL, Redis, Kafka, Elastic Search, and so on.
+### AI Hub
 
-Zeabur can help you easily deploy them in the same place, reduce management costs, and improve transmission speeds.
+[AI Hub](https://zeabur.com/docs/ai-hub) is a unified AI service platform giving you access to multiple AI models (OpenAI GPT, Anthropic Claude, xAI Grok, and more) through a single API key.
 
-### Easy to manage
+- Compatible with the OpenAI API format — drop it into existing applications with minimal changes.
+- Transparent pay-as-you-go billing per token with full usage history.
+- Multi-region endpoints (Tokyo, San Francisco) for optimal latency.
 
-After deployment, you can easily manage your services through the dashboard.
+### Domain
 
-- You can check the status or usages of your services, your them.
-- Rollback, suspend or restart your services with one click.
-- Invite your team members to manage your services together!
-- You can also see a detailed log of your services.
+Zeabur provides full [domain management](https://zeabur.com/docs/domain) capabilities:
+
+- Register and manage domains directly from the Zeabur dashboard.
+- Assign free `zeabur.app` subdomains or bring your own custom domain with one click.
+- Manage DNS records and registrant profiles in the same place.
+
+### Email
+
+[Zeabur Email](https://zeabur.com/docs/email) is an enterprise-grade email sending API service built on AWS SES with a 99.9% uptime guarantee.
+
+- Simple REST API for instant, scheduled, and batch sending.
+- Webhook notifications for delivery, bounce, and complaint events.
+- Custom sender domain support with DKIM/SPF verification.
+
+### Templates
+
+Zeabur offers a rich catalog of [one-click deployment templates](https://zeabur.com/templates) for popular services — WordPress, Postgres, Redis, n8n, Ghost, and hundreds more.
+
+- Each template pre-wires services, environment variables, and connection settings automatically.
+- Create and share your own templates via YAML.
+
+### Integrations
+
+Zeabur provides [built-in integrations](https://zeabur.com/docs/integrations) with third-party services so you can add powerful backend capabilities to your project without separate deployments.
+
+- **InsForge** — An agent-native Supabase alternative with PostgreSQL, JWT auth, S3-compatible storage, serverless edge functions, and MCP protocol support for AI IDE integration.
+
+### Powerful Configuration
+
+- Environment variables managed from the dashboard — no `.env` files required.
+- Multiple environment support (`production`, `staging`, `development`, etc.) with separate domains and branches.
+- Rollback, suspend, restart, and scale services with one click.
+- Invite team members to collaborate on the same project.
+
+### Pay as You Go
+
+Zeabur uses a consumption-based pricing model — you only pay for the resources your services actually use, billed by the minute.
+
+See the [pricing page](https://zeabur.com/docs/pricing) for details.
+
+### Developer Tools
+
+- **[GraphQL API](https://api.zeabur.com/graphql)** — Full programmatic access to projects, services, deployments, and logs.
+- **[Zeabur CLI](https://zeabur.com/docs/developer/cli)** — Deploy and manage services from your terminal with `npx zeabur`.
+- **REST APIs** — Upload API for ZIP deployments, Email REST API, and more.
+- **WebSocket subscriptions** — Stream real-time logs and project events.
+
+## Community & Support
+
+- **[Community Forum](https://zeabur.com/forum)** — Official support hub for questions, issues, and discussions. Priority response times for paid plans.
+- **[Discord](https://discord.gg/DrdGCvXEyY)** — Chat with the Zeabur community.
+- **[GitHub Discussions](https://github.com/orgs/zeabur/discussions)** — Feature requests and community discussions.
 
 ## Documentation
 
-For details on how to use Zeabur, check out our [documentation](https://zeabur.com/docs).
+For full details, visit [zeabur.com/docs](https://zeabur.com/docs).
 
-## Contributing Dashboard Localization
+## Contributing
 
-Contact us on [Discord](https://zeabur.com/dc). You can apply for the [Reward Program](https://zeabur.com/docs/billing/reward) for this contribution.
+### Dashboard Localization
+
+Help translate the Zeabur dashboard and earn credits through the [Contribution Reward Program](https://zeabur.com/docs/rewards/contribution). Contact us on [Discord](https://zeabur.com/dc) or the [forum](https://zeabur.com/forum) to get started.
+
+### Templates
+
+Publish a template to the [template marketplace](https://zeabur.com/templates) and earn rewards. See the [template format guide](https://zeabur.com/docs/template/template-format) to get started.


### PR DESCRIPTION
Add Servers, Wonder Mesh, AI Hub, Domain, Email, Templates, Integrations,
and Developer Tools sections. Replace the outdated features list with
accurate descriptions sourced from the current documentation. Update
community links to include the forum and refresh contributing section.

https://claude.ai/code/session_01PfnnLSUb1Z8pEY5UAgzq17

Fixed ZEA-9220

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated top navigation with Templates and Forum links; removed standalone GitHub Discussions link
  * Replaced Intro with “Your AI DevOps Engineer” and reframed feature descriptions toward AI-native development and AI-enabled build/deploy
  * Reorganized platform overview (Servers & Clusters, AI Hub, Wonder Mesh, Domain, Email, Templates, Powerful Configuration, Developer Tools)
  * Added Community & Support and streamlined Documentation and Contributing sections
<!-- end of auto-generated comment: release notes by coderabbit.ai -->