### PR TITLE
docs(developer): sync Agent Skills install slug (zeabur-claude-plugin → agent-skills)

### DIFF
--- a/docs/pages/en-US/developer/claude-code-skills.mdx
+++ b/docs/pages/en-US/developer/claude-code-skills.mdx
@@ -23,7 +23,7 @@ Zeabur's official Claude Code plugin converts natural language into infrastructu
 Add the Zeabur plugin from the Claude Code marketplace:
 
 ```bash copy
-claude plugin marketplace add zeabur/zeabur-claude-plugin
+claude plugin marketplace add zeabur/agent-skills
 ```
 
 ### Install and activate the skills

--- a/docs/pages/es-ES/developer/claude-code-skills.mdx
+++ b/docs/pages/es-ES/developer/claude-code-skills.mdx
@@ -23,7 +23,7 @@ El plugin oficial de Zeabur para Claude Code convierte el lenguaje natural en op
 Añade el plugin de Zeabur desde el marketplace de Claude Code:
 
 ```bash copy
-claude plugin marketplace add zeabur/zeabur-claude-plugin
+claude plugin marketplace add zeabur/agent-skills
 ```
 
 ### Instala y activa los skills

--- a/docs/pages/ja-JP/developer/claude-code-skills.mdx
+++ b/docs/pages/ja-JP/developer/claude-code-skills.mdx
@@ -23,7 +23,7 @@ Zeabur 公式の Claude Code プラグインは、自然言語をインフラ操
 Claude Code マーケットプレイスから Zeabur プラグインを追加：
 
 ```bash copy
-claude plugin marketplace add zeabur/zeabur-claude-plugin
+claude plugin marketplace add zeabur/agent-skills
 ```
 
 ### Skills をインストールして有効化

--- a/docs/pages/zh-CN/developer/claude-code-skills.mdx
+++ b/docs/pages/zh-CN/developer/claude-code-skills.mdx
@@ -23,7 +23,7 @@ Zeabur 官方 Claude Code 插件将自然语言转换为基础设施操作。部
 从 Claude Code 市场添加 Zeabur 插件：
 
 ```bash copy
-claude plugin marketplace add zeabur/zeabur-claude-plugin
+claude plugin marketplace add zeabur/agent-skills
 ```
 
 ### 安装并激活 Skills

--- a/docs/pages/zh-TW/developer/claude-code-skills.mdx
+++ b/docs/pages/zh-TW/developer/claude-code-skills.mdx
@@ -23,7 +23,7 @@ Zeabur 官方 Claude Code 外掛將自然語言轉化為基礎設施操作。部
 從 Claude Code 市集新增 Zeabur 外掛：
 
 ```bash copy
-claude plugin marketplace add zeabur/zeabur-claude-plugin
+claude plugin marketplace add zeabur/agent-skills
 ```
 
 ### 安裝並啟用 Skills


### PR DESCRIPTION
## Summary
- GitHub repo was renamed from `zeabur/zeabur-claude-plugin` to `zeabur/agent-skills`
- Old slug still works via GitHub redirect, but the canonical form in the README is `zeabur/agent-skills`
- Updates the `claude plugin marketplace add` install command in all 5 locale doc files

## Why
- Blog post [MKT-2011 PR #550](https://github.com/zeabur/zeabur.com/pull/550) uses the canonical slug; this PR aligns the public docs so the three sources (repo README, public docs, blog) all match
- Follow-up PR in `zebra-manual` already landed to sync internal references

## Test plan
- [ ] Visual check on docs preview
- [ ] `claude plugin marketplace add zeabur/agent-skills && claude plugin install zeabur@zeabur` actually installs the plugin (unchanged behavior — both slugs resolve to same repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Claude Code Skills installation instructions with the new marketplace plugin identifier across documentation in English, Spanish, Japanese, Chinese Simplified, and Traditional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->