### PR TITLE
docs: fix feedback 500 on locale-root pages (SEI-472)

### DIFF
--- a/docs/components/FeedbackWidget/index.tsx
+++ b/docs/components/FeedbackWidget/index.tsx
@@ -223,7 +223,7 @@ export default function FeedbackWidget({ variant = 'toc' }: { variant?: 'toc' | 
         return
       }
 
-      const page = router.asPath.replace(/^\/[a-z]{2}-[A-Z]{2}/, '').replace(/#.*$/, '')
+      const page = router.asPath.replace(/^\/[a-z]{2}-[A-Z]{2}/, '').replace(/[?#].*$/, '') || '/'
 
       const res = await fetch('https://api.zeabur.com/graphql', {
         method: 'POST',


### PR DESCRIPTION
## Summary
- `router.asPath.replace(/^\/[a-z]{2}-[A-Z]{2}/, '')` left `page` empty on locale-root URLs (e.g. `/en-US`, `/zh-TW`), which the gateway's `SubmitDocFeedback` resolver rejects as `invalid page` and returns as a generic `INTERNAL_SERVER_ERROR`.
- Default `page` to `/` when the stripped path is empty, and strip query strings alongside the hash so the payload stays canonical.

Linear: https://linear.app/zeabur/issue/SEI-472/doc-intro-page-feedback-err
Trace: `d2c0251a49d51df0d0f545c20060541e`

## Test plan
- [ ] Submit feedback from `/docs/en-US` (locale root) → expect 200
- [ ] Submit feedback from `/docs/en-US/ai-hub` (non-root) → still 200
- [ ] Submit from a URL with `?foo=bar` → request payload omits the query string

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced page tracking accuracy for feedback submissions to ensure the correct page context is captured when submitting feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->