### PR TITLE
docs: add GCP BYOS guide

### DIFF
--- a/docs/pages/en-US/byos/_meta.ts
+++ b/docs/pages/en-US/byos/_meta.ts
@@ -1,3 +1,4 @@
 export default {
   aws: 'AWS',
+  gcp: 'GCP',
 }

--- a/docs/pages/en-US/byos/gcp.mdx
+++ b/docs/pages/en-US/byos/gcp.mdx
@@ -33,7 +33,7 @@ Zeabur uses a service account in your project (`zeabur-connector`) to manage GKE
 
 Open [Cloud Shell](https://shell.cloud.google.com/) (or any terminal with `gcloud` authenticated), set `PROJECT_ID`, and run:
 
-```bash
+```bash copy
 export PROJECT_ID=your-gcp-project-id
 
 gcloud services enable \
@@ -59,7 +59,7 @@ gcloud iam service-accounts add-iam-policy-binding \
 
 Paste the following prompt into [Claude Code](https://claude.com/claude-code) or [Codex CLI](https://github.com/openai/codex) — the agent will run the commands for you and report back with the values you need:
 
-```text
+```text copy
 Set up Zeabur BYOS for GKE on a GCP project. Use gcloud (assume I'm authenticated).
 
 1. Ask me which GCP project to use, or create a new one.

--- a/docs/pages/en-US/byos/gcp.mdx
+++ b/docs/pages/en-US/byos/gcp.mdx
@@ -1,0 +1,90 @@
+---
+title: GCP BYOS
+ogImageTitle: GCP BYOS
+ogImageSubtitle: Bring your own GCP project to Zeabur
+---
+
+import { Steps, Tabs } from 'nextra/components'
+
+# GCP BYOS (Bring Your Own Subscription)
+
+By linking your own GCP project to Zeabur, you can let Zeabur create GKE clusters and manage services directly in your GCP project.
+
+<Steps>
+
+### Prepare a GCP project with billing
+
+Pick the GCP project you want Zeabur to use, or [create a new one](https://console.cloud.google.com/projectcreate). Make sure the project is linked to a billing account — GKE will not run without it.
+
+### Set up the connector service account
+
+Zeabur uses a service account in your project (`zeabur-connector`) to manage GKE clusters, and impersonates it through `zeabur-byos-connector@zeabur-system.iam.gserviceaccount.com`. Pick one of the three setup paths below.
+
+<Tabs storageKey="gcp-byos-setup" items={['Cloud Console', 'gcloud CLI', 'Claude Code / Codex']}>
+<Tabs.Tab>
+
+1. In your project's API library, enable [Kubernetes Engine API](https://console.cloud.google.com/apis/library/container.googleapis.com) and [Cloud Resource Manager API](https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com).
+2. Go to **IAM & Admin → Service Accounts** and create a service account named `zeabur-connector`.
+3. Go to **IAM & Admin → IAM**, click **Grant Access**, add `zeabur-connector@<PROJECT_ID>.iam.gserviceaccount.com` as a principal, and assign the `roles/container.admin` role.
+4. Back in **Service Accounts**, open `zeabur-connector`, switch to the **Permissions** tab, click **Grant Access**, add `zeabur-byos-connector@zeabur-system.iam.gserviceaccount.com` as a principal, and assign the `roles/iam.serviceAccountTokenCreator` role.
+
+</Tabs.Tab>
+<Tabs.Tab>
+
+Open [Cloud Shell](https://shell.cloud.google.com/) (or any terminal with `gcloud` authenticated), set `PROJECT_ID`, and run:
+
+```bash
+export PROJECT_ID=your-gcp-project-id
+
+gcloud services enable \
+  container.googleapis.com \
+  cloudresourcemanager.googleapis.com \
+  --project=$PROJECT_ID
+
+gcloud iam service-accounts create zeabur-connector --project=$PROJECT_ID
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:zeabur-connector@$PROJECT_ID.iam.gserviceaccount.com" \
+  --role="roles/container.admin"
+
+gcloud iam service-accounts add-iam-policy-binding \
+  zeabur-connector@$PROJECT_ID.iam.gserviceaccount.com \
+  --member="serviceAccount:zeabur-byos-connector@zeabur-system.iam.gserviceaccount.com" \
+  --role="roles/iam.serviceAccountTokenCreator" \
+  --project=$PROJECT_ID
+```
+
+</Tabs.Tab>
+<Tabs.Tab>
+
+Paste the following prompt into [Claude Code](https://claude.com/claude-code) or [Codex CLI](https://github.com/openai/codex) — the agent will run the commands for you and report back with the values you need:
+
+```text
+Set up Zeabur BYOS for GKE on a GCP project. Use gcloud (assume I'm authenticated).
+
+1. Ask me which GCP project to use, or create a new one.
+2. Make sure the project is linked to a billing account.
+3. Run these commands (substitute PROJECT_ID):
+   - gcloud services enable container.googleapis.com cloudresourcemanager.googleapis.com --project=PROJECT_ID
+   - gcloud iam service-accounts create zeabur-connector --project=PROJECT_ID
+   - gcloud projects add-iam-policy-binding PROJECT_ID --member="serviceAccount:zeabur-connector@PROJECT_ID.iam.gserviceaccount.com" --role="roles/container.admin"
+   - gcloud iam service-accounts add-iam-policy-binding zeabur-connector@PROJECT_ID.iam.gserviceaccount.com --member="serviceAccount:zeabur-byos-connector@zeabur-system.iam.gserviceaccount.com" --role="roles/iam.serviceAccountTokenCreator" --project=PROJECT_ID
+
+When done, print the project ID and the connector service account email so I can paste them into Zeabur's Bind GCP Service Account form.
+```
+
+</Tabs.Tab>
+</Tabs>
+
+### Bind the project to Zeabur
+
+Go to [https://zeabur.com/account/byos](https://zeabur.com/account/byos), click **Bind GCP Service Account**, and submit:
+
+- **Service Account Email**: `zeabur-connector@<PROJECT_ID>.iam.gserviceaccount.com`
+- **Project ID**: your GCP project ID
+
+### Purchase a dedicated cluster
+
+Once the service account is bound, go to the [Buy Cluster](https://zeabur.com/servers/buy-cluster) page. You will see a new provider option named **GCP - &lt;project name&gt;**. Select it, and Zeabur will create a new GKE cluster directly in your GCP project.
+
+</Steps>

--- a/docs/pages/es-ES/byos/_meta.ts
+++ b/docs/pages/es-ES/byos/_meta.ts
@@ -1,3 +1,4 @@
 export default {
   aws: 'AWS',
+  gcp: 'GCP',
 }

--- a/docs/pages/es-ES/byos/gcp.mdx
+++ b/docs/pages/es-ES/byos/gcp.mdx
@@ -33,7 +33,7 @@ Zeabur usa una service account llamada `zeabur-connector` en tu proyecto para ad
 
 Abre [Cloud Shell](https://shell.cloud.google.com/) (o cualquier terminal con `gcloud` autenticado), define `PROJECT_ID` y ejecuta:
 
-```bash
+```bash copy
 export PROJECT_ID=your-gcp-project-id
 
 gcloud services enable \
@@ -59,7 +59,7 @@ gcloud iam service-accounts add-iam-policy-binding \
 
 Pega el siguiente prompt en [Claude Code](https://claude.com/claude-code) o [Codex CLI](https://github.com/openai/codex) — el agente ejecutará los comandos por ti y te devolverá los valores que necesitas:
 
-```text
+```text copy
 Set up Zeabur BYOS for GKE on a GCP project. Use gcloud (assume I'm authenticated).
 
 1. Ask me which GCP project to use, or create a new one.

--- a/docs/pages/es-ES/byos/gcp.mdx
+++ b/docs/pages/es-ES/byos/gcp.mdx
@@ -1,0 +1,90 @@
+---
+title: GCP BYOS
+ogImageTitle: GCP BYOS
+ogImageSubtitle: Usa tu propio proyecto de GCP con Zeabur
+---
+
+import { Steps, Tabs } from 'nextra/components'
+
+# GCP BYOS (Trae tu propia suscripción)
+
+Al vincular tu propio proyecto de GCP a Zeabur, puedes permitir que Zeabur cree clústeres de GKE y administre servicios directamente en tu proyecto de GCP.
+
+<Steps>
+
+### Prepara un proyecto de GCP con billing vinculado
+
+Elige el proyecto de GCP que quieres que Zeabur use, o [crea uno nuevo](https://console.cloud.google.com/projectcreate). Asegúrate de que el proyecto esté vinculado a una cuenta de billing — GKE no funciona sin billing.
+
+### Configura la connector service account
+
+Zeabur usa una service account llamada `zeabur-connector` en tu proyecto para administrar los clústeres de GKE, y hace impersonation a través de `zeabur-byos-connector@zeabur-system.iam.gserviceaccount.com`. Elige una de las tres rutas de configuración a continuación.
+
+<Tabs storageKey="gcp-byos-setup" items={['Cloud Console', 'gcloud CLI', 'Claude Code / Codex']}>
+<Tabs.Tab>
+
+1. En la biblioteca de APIs de tu proyecto, habilita [Kubernetes Engine API](https://console.cloud.google.com/apis/library/container.googleapis.com) y [Cloud Resource Manager API](https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com).
+2. Ve a **IAM y administración → Cuentas de servicio** y crea una service account llamada `zeabur-connector`.
+3. Ve a **IAM y administración → IAM**, haz clic en **Otorgar acceso**, agrega `zeabur-connector@<PROJECT_ID>.iam.gserviceaccount.com` como principal y asigna el rol `roles/container.admin`.
+4. Vuelve a **Cuentas de servicio**, abre `zeabur-connector`, ve a la pestaña **Permisos**, haz clic en **Otorgar acceso**, agrega `zeabur-byos-connector@zeabur-system.iam.gserviceaccount.com` como principal y asigna el rol `roles/iam.serviceAccountTokenCreator`.
+
+</Tabs.Tab>
+<Tabs.Tab>
+
+Abre [Cloud Shell](https://shell.cloud.google.com/) (o cualquier terminal con `gcloud` autenticado), define `PROJECT_ID` y ejecuta:
+
+```bash
+export PROJECT_ID=your-gcp-project-id
+
+gcloud services enable \
+  container.googleapis.com \
+  cloudresourcemanager.googleapis.com \
+  --project=$PROJECT_ID
+
+gcloud iam service-accounts create zeabur-connector --project=$PROJECT_ID
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:zeabur-connector@$PROJECT_ID.iam.gserviceaccount.com" \
+  --role="roles/container.admin"
+
+gcloud iam service-accounts add-iam-policy-binding \
+  zeabur-connector@$PROJECT_ID.iam.gserviceaccount.com \
+  --member="serviceAccount:zeabur-byos-connector@zeabur-system.iam.gserviceaccount.com" \
+  --role="roles/iam.serviceAccountTokenCreator" \
+  --project=$PROJECT_ID
+```
+
+</Tabs.Tab>
+<Tabs.Tab>
+
+Pega el siguiente prompt en [Claude Code](https://claude.com/claude-code) o [Codex CLI](https://github.com/openai/codex) — el agente ejecutará los comandos por ti y te devolverá los valores que necesitas:
+
+```text
+Set up Zeabur BYOS for GKE on a GCP project. Use gcloud (assume I'm authenticated).
+
+1. Ask me which GCP project to use, or create a new one.
+2. Make sure the project is linked to a billing account.
+3. Run these commands (substitute PROJECT_ID):
+   - gcloud services enable container.googleapis.com cloudresourcemanager.googleapis.com --project=PROJECT_ID
+   - gcloud iam service-accounts create zeabur-connector --project=PROJECT_ID
+   - gcloud projects add-iam-policy-binding PROJECT_ID --member="serviceAccount:zeabur-connector@PROJECT_ID.iam.gserviceaccount.com" --role="roles/container.admin"
+   - gcloud iam service-accounts add-iam-policy-binding zeabur-connector@PROJECT_ID.iam.gserviceaccount.com --member="serviceAccount:zeabur-byos-connector@zeabur-system.iam.gserviceaccount.com" --role="roles/iam.serviceAccountTokenCreator" --project=PROJECT_ID
+
+When done, print the project ID and the connector service account email so I can paste them into Zeabur's Bind GCP Service Account form.
+```
+
+</Tabs.Tab>
+</Tabs>
+
+### Vincula el proyecto a Zeabur
+
+Ve a [https://zeabur.com/account/byos](https://zeabur.com/account/byos), haz clic en **Vincular GCP Service Account** y envía:
+
+- **Service Account Email**: `zeabur-connector@<PROJECT_ID>.iam.gserviceaccount.com`
+- **ID del proyecto**: tu ID de proyecto de GCP
+
+### Compra un clúster dedicado
+
+Una vez vinculada la service account, ve a la página [Comprar clúster](https://zeabur.com/servers/buy-cluster). Verás una nueva opción de proveedor llamada **GCP - &lt;nombre del proyecto&gt;**. Selecciónala y Zeabur creará un nuevo clúster de GKE directamente en tu proyecto de GCP.
+
+</Steps>

--- a/docs/pages/ja-JP/byos/_meta.ts
+++ b/docs/pages/ja-JP/byos/_meta.ts
@@ -1,3 +1,4 @@
 export default {
   aws: 'AWS',
+  gcp: 'GCP',
 }

--- a/docs/pages/ja-JP/byos/gcp.mdx
+++ b/docs/pages/ja-JP/byos/gcp.mdx
@@ -33,7 +33,7 @@ Zeabur はあなたのプロジェクト内の `zeabur-connector` という serv
 
 [Cloud Shell](https://shell.cloud.google.com/)（または `gcloud` で認証済みの任意のターミナル）を開き、`PROJECT_ID` を設定して以下を実行します：
 
-```bash
+```bash copy
 export PROJECT_ID=your-gcp-project-id
 
 gcloud services enable \
@@ -59,7 +59,7 @@ gcloud iam service-accounts add-iam-policy-binding \
 
 以下のプロンプトを [Claude Code](https://claude.com/claude-code) または [Codex CLI](https://github.com/openai/codex) に貼り付けてください——AI エージェントがコマンドを実行し、必要な情報を返してくれます：
 
-```text
+```text copy
 Set up Zeabur BYOS for GKE on a GCP project. Use gcloud (assume I'm authenticated).
 
 1. Ask me which GCP project to use, or create a new one.

--- a/docs/pages/ja-JP/byos/gcp.mdx
+++ b/docs/pages/ja-JP/byos/gcp.mdx
@@ -1,0 +1,90 @@
+---
+title: GCP BYOS
+ogImageTitle: GCP BYOS
+ogImageSubtitle: 自分の GCP プロジェクトを Zeabur に連携する
+---
+
+import { Steps, Tabs } from 'nextra/components'
+
+# GCP BYOS（サブスクリプション持ち込み）
+
+自分の GCP プロジェクトを Zeabur にリンクすることで、Zeabur があなたの GCP プロジェクト上で直接 GKE クラスターの作成やサービスの管理を行えるようになります。
+
+<Steps>
+
+### Billing が紐付いた GCP プロジェクトを準備
+
+Zeabur に使わせたい GCP プロジェクトを選ぶか、[新しく作成](https://console.cloud.google.com/projectcreate)します。プロジェクトが billing account に紐付いていることを確認してください——billing がないと GKE は動作しません。
+
+### Connector service account をセットアップ
+
+Zeabur はあなたのプロジェクト内の `zeabur-connector` という service account を使って GKE クラスターを管理し、`zeabur-byos-connector@zeabur-system.iam.gserviceaccount.com` を通じて impersonation を行います。下記 3 つのセットアップ方法のいずれかを選んでください。
+
+<Tabs storageKey="gcp-byos-setup" items={['Cloud Console', 'gcloud CLI', 'Claude Code / Codex']}>
+<Tabs.Tab>
+
+1. プロジェクトの API ライブラリで [Kubernetes Engine API](https://console.cloud.google.com/apis/library/container.googleapis.com) と [Cloud Resource Manager API](https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com) を有効化します。
+2. **IAM と管理 → サービス アカウント** に進み、`zeabur-connector` という service account を作成します。
+3. **IAM と管理 → IAM** に進み、**アクセスを許可** をクリックして、`zeabur-connector@<PROJECT_ID>.iam.gserviceaccount.com` をプリンシパルとして追加し、`roles/container.admin` ロールを付与します。
+4. **サービス アカウント** に戻り、`zeabur-connector` を開いて **権限** タブに切り替え、**アクセスを許可** をクリックして、`zeabur-byos-connector@zeabur-system.iam.gserviceaccount.com` をプリンシパルとして追加し、`roles/iam.serviceAccountTokenCreator` ロールを付与します。
+
+</Tabs.Tab>
+<Tabs.Tab>
+
+[Cloud Shell](https://shell.cloud.google.com/)（または `gcloud` で認証済みの任意のターミナル）を開き、`PROJECT_ID` を設定して以下を実行します：
+
+```bash
+export PROJECT_ID=your-gcp-project-id
+
+gcloud services enable \
+  container.googleapis.com \
+  cloudresourcemanager.googleapis.com \
+  --project=$PROJECT_ID
+
+gcloud iam service-accounts create zeabur-connector --project=$PROJECT_ID
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:zeabur-connector@$PROJECT_ID.iam.gserviceaccount.com" \
+  --role="roles/container.admin"
+
+gcloud iam service-accounts add-iam-policy-binding \
+  zeabur-connector@$PROJECT_ID.iam.gserviceaccount.com \
+  --member="serviceAccount:zeabur-byos-connector@zeabur-system.iam.gserviceaccount.com" \
+  --role="roles/iam.serviceAccountTokenCreator" \
+  --project=$PROJECT_ID
+```
+
+</Tabs.Tab>
+<Tabs.Tab>
+
+以下のプロンプトを [Claude Code](https://claude.com/claude-code) または [Codex CLI](https://github.com/openai/codex) に貼り付けてください——AI エージェントがコマンドを実行し、必要な情報を返してくれます：
+
+```text
+Set up Zeabur BYOS for GKE on a GCP project. Use gcloud (assume I'm authenticated).
+
+1. Ask me which GCP project to use, or create a new one.
+2. Make sure the project is linked to a billing account.
+3. Run these commands (substitute PROJECT_ID):
+   - gcloud services enable container.googleapis.com cloudresourcemanager.googleapis.com --project=PROJECT_ID
+   - gcloud iam service-accounts create zeabur-connector --project=PROJECT_ID
+   - gcloud projects add-iam-policy-binding PROJECT_ID --member="serviceAccount:zeabur-connector@PROJECT_ID.iam.gserviceaccount.com" --role="roles/container.admin"
+   - gcloud iam service-accounts add-iam-policy-binding zeabur-connector@PROJECT_ID.iam.gserviceaccount.com --member="serviceAccount:zeabur-byos-connector@zeabur-system.iam.gserviceaccount.com" --role="roles/iam.serviceAccountTokenCreator" --project=PROJECT_ID
+
+When done, print the project ID and the connector service account email so I can paste them into Zeabur's Bind GCP Service Account form.
+```
+
+</Tabs.Tab>
+</Tabs>
+
+### プロジェクトを Zeabur にバインド
+
+[https://zeabur.com/account/byos](https://zeabur.com/account/byos) にアクセスし、**GCP Service Account をバインド** をクリックして、以下を送信します：
+
+- **Service Account Email**：`zeabur-connector@<PROJECT_ID>.iam.gserviceaccount.com`
+- **プロジェクト ID**：あなたの GCP プロジェクト ID
+
+### 専用クラスターを購入
+
+Service account のバインドが完了したら、[クラスター購入](https://zeabur.com/servers/buy-cluster)ページに進みます。**GCP - &lt;プロジェクト名&gt;** という新しいプロバイダオプションが表示されます。これを選択すると、Zeabur があなたの GCP プロジェクト上で新しい GKE クラスターを作成します。
+
+</Steps>

--- a/docs/pages/zh-CN/byos/_meta.ts
+++ b/docs/pages/zh-CN/byos/_meta.ts
@@ -1,3 +1,4 @@
 export default {
   aws: 'AWS',
+  gcp: 'GCP',
 }

--- a/docs/pages/zh-CN/byos/gcp.mdx
+++ b/docs/pages/zh-CN/byos/gcp.mdx
@@ -33,7 +33,7 @@ Zeabur 会在你的项目里用一个叫 `zeabur-connector` 的 service account 
 
 打开 [Cloud Shell](https://shell.cloud.google.com/)（或任何已认证 `gcloud` 的终端），设置 `PROJECT_ID` 后运行：
 
-```bash
+```bash copy
 export PROJECT_ID=your-gcp-project-id
 
 gcloud services enable \
@@ -59,7 +59,7 @@ gcloud iam service-accounts add-iam-policy-binding \
 
 把以下 prompt 贴到 [Claude Code](https://claude.com/claude-code) 或 [Codex CLI](https://github.com/openai/codex)——AI agent 会帮你跑完所有命令并回报你需要的信息：
 
-```text
+```text copy
 Set up Zeabur BYOS for GKE on a GCP project. Use gcloud (assume I'm authenticated).
 
 1. Ask me which GCP project to use, or create a new one.

--- a/docs/pages/zh-CN/byos/gcp.mdx
+++ b/docs/pages/zh-CN/byos/gcp.mdx
@@ -1,0 +1,90 @@
+---
+title: GCP BYOS
+ogImageTitle: GCP BYOS
+ogImageSubtitle: 使用自己的 GCP 项目授权给 Zeabur
+---
+
+import { Steps, Tabs } from 'nextra/components'
+
+# GCP BYOS（自带订阅）
+
+将你自己的 GCP 项目连接到 Zeabur，让 Zeabur 直接在你的 GCP 项目中创建 GKE 集群、管理服务。
+
+<Steps>
+
+### 准备一个已绑定 billing 的 GCP 项目
+
+选一个你想让 Zeabur 使用的 GCP 项目，或[创建一个新的](https://console.cloud.google.com/projectcreate)。确认项目已绑定 billing account——没绑 billing 的话 GKE 无法运行。
+
+### 设置 connector service account
+
+Zeabur 会在你的项目里用一个叫 `zeabur-connector` 的 service account 管理 GKE 集群，并通过 `zeabur-byos-connector@zeabur-system.iam.gserviceaccount.com` 进行 impersonation。下面三种设置方式择一即可。
+
+<Tabs storageKey="gcp-byos-setup" items={['Cloud Console', 'gcloud CLI', 'Claude Code / Codex']}>
+<Tabs.Tab>
+
+1. 在项目的 API 库中启用 [Kubernetes Engine API](https://console.cloud.google.com/apis/library/container.googleapis.com) 与 [Cloud Resource Manager API](https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com)。
+2. 进入 **IAM 与管理 → 服务账号**，创建一个名为 `zeabur-connector` 的 service account。
+3. 进入 **IAM 与管理 → IAM**，点 **授予访问权限**，把 `zeabur-connector@<PROJECT_ID>.iam.gserviceaccount.com` 添加为主体并赋予 `roles/container.admin` 角色。
+4. 回到 **服务账号**，点开 `zeabur-connector`，切换到 **权限** 标签，点 **授予访问权限**，把 `zeabur-byos-connector@zeabur-system.iam.gserviceaccount.com` 添加为主体并赋予 `roles/iam.serviceAccountTokenCreator` 角色。
+
+</Tabs.Tab>
+<Tabs.Tab>
+
+打开 [Cloud Shell](https://shell.cloud.google.com/)（或任何已认证 `gcloud` 的终端），设置 `PROJECT_ID` 后运行：
+
+```bash
+export PROJECT_ID=your-gcp-project-id
+
+gcloud services enable \
+  container.googleapis.com \
+  cloudresourcemanager.googleapis.com \
+  --project=$PROJECT_ID
+
+gcloud iam service-accounts create zeabur-connector --project=$PROJECT_ID
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:zeabur-connector@$PROJECT_ID.iam.gserviceaccount.com" \
+  --role="roles/container.admin"
+
+gcloud iam service-accounts add-iam-policy-binding \
+  zeabur-connector@$PROJECT_ID.iam.gserviceaccount.com \
+  --member="serviceAccount:zeabur-byos-connector@zeabur-system.iam.gserviceaccount.com" \
+  --role="roles/iam.serviceAccountTokenCreator" \
+  --project=$PROJECT_ID
+```
+
+</Tabs.Tab>
+<Tabs.Tab>
+
+把以下 prompt 贴到 [Claude Code](https://claude.com/claude-code) 或 [Codex CLI](https://github.com/openai/codex)——AI agent 会帮你跑完所有命令并回报你需要的信息：
+
+```text
+Set up Zeabur BYOS for GKE on a GCP project. Use gcloud (assume I'm authenticated).
+
+1. Ask me which GCP project to use, or create a new one.
+2. Make sure the project is linked to a billing account.
+3. Run these commands (substitute PROJECT_ID):
+   - gcloud services enable container.googleapis.com cloudresourcemanager.googleapis.com --project=PROJECT_ID
+   - gcloud iam service-accounts create zeabur-connector --project=PROJECT_ID
+   - gcloud projects add-iam-policy-binding PROJECT_ID --member="serviceAccount:zeabur-connector@PROJECT_ID.iam.gserviceaccount.com" --role="roles/container.admin"
+   - gcloud iam service-accounts add-iam-policy-binding zeabur-connector@PROJECT_ID.iam.gserviceaccount.com --member="serviceAccount:zeabur-byos-connector@zeabur-system.iam.gserviceaccount.com" --role="roles/iam.serviceAccountTokenCreator" --project=PROJECT_ID
+
+When done, print the project ID and the connector service account email so I can paste them into Zeabur's Bind GCP Service Account form.
+```
+
+</Tabs.Tab>
+</Tabs>
+
+### 将项目绑定到 Zeabur
+
+前往 [https://zeabur.com/account/byos](https://zeabur.com/account/byos)，点击 **绑定 GCP Service Account**，填入以下信息后提交：
+
+- **Service Account Email**：`zeabur-connector@<PROJECT_ID>.iam.gserviceaccount.com`
+- **项目 ID**：你的 GCP 项目 ID
+
+### 购买专属集群
+
+Service account 绑定完成后，前往[购买集群](https://zeabur.com/servers/buy-cluster)页面。你会看到一个新的 provider 选项 **GCP - &lt;项目名称&gt;**。选它，Zeabur 就会直接在你的 GCP 项目中创建一个新的 GKE 集群。
+
+</Steps>

--- a/docs/pages/zh-TW/byos/_meta.ts
+++ b/docs/pages/zh-TW/byos/_meta.ts
@@ -1,3 +1,4 @@
 export default {
   aws: 'AWS',
+  gcp: 'GCP',
 }

--- a/docs/pages/zh-TW/byos/gcp.mdx
+++ b/docs/pages/zh-TW/byos/gcp.mdx
@@ -33,7 +33,7 @@ Zeabur 會在你的專案裡用一個叫 `zeabur-connector` 的 service account 
 
 開啟 [Cloud Shell](https://shell.cloud.google.com/)（或任何已驗證 `gcloud` 的終端機），設定 `PROJECT_ID` 後執行：
 
-```bash
+```bash copy
 export PROJECT_ID=your-gcp-project-id
 
 gcloud services enable \
@@ -59,7 +59,7 @@ gcloud iam service-accounts add-iam-policy-binding \
 
 把以下 prompt 貼到 [Claude Code](https://claude.com/claude-code) 或 [Codex CLI](https://github.com/openai/codex)——AI agent 會幫你跑完所有指令並回報你需要的資訊：
 
-```text
+```text copy
 Set up Zeabur BYOS for GKE on a GCP project. Use gcloud (assume I'm authenticated).
 
 1. Ask me which GCP project to use, or create a new one.

--- a/docs/pages/zh-TW/byos/gcp.mdx
+++ b/docs/pages/zh-TW/byos/gcp.mdx
@@ -1,0 +1,90 @@
+---
+title: GCP BYOS
+ogImageTitle: GCP BYOS
+ogImageSubtitle: 使用自己的 GCP 專案授權給 Zeabur
+---
+
+import { Steps, Tabs } from 'nextra/components'
+
+# GCP BYOS（自帶訂閱）
+
+將你自己的 GCP 專案連結到 Zeabur，讓 Zeabur 直接在你的 GCP 專案中建立 GKE 叢集、管理服務。
+
+<Steps>
+
+### 準備一個已綁定 billing 的 GCP 專案
+
+選一個你想讓 Zeabur 使用的 GCP 專案，或[建立一個新的](https://console.cloud.google.com/projectcreate)。確認專案已綁定 billing account——沒綁 billing 的話 GKE 無法運作。
+
+### 設定 connector service account
+
+Zeabur 會在你的專案裡用一個叫 `zeabur-connector` 的 service account 管理 GKE 叢集，並透過 `zeabur-byos-connector@zeabur-system.iam.gserviceaccount.com` 進行 impersonation。下面三種設定方式擇一即可。
+
+<Tabs storageKey="gcp-byos-setup" items={['Cloud Console', 'gcloud CLI', 'Claude Code / Codex']}>
+<Tabs.Tab>
+
+1. 在專案的 API 程式庫中啟用 [Kubernetes Engine API](https://console.cloud.google.com/apis/library/container.googleapis.com) 與 [Cloud Resource Manager API](https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com)。
+2. 進到 **IAM 與管理 → 服務帳戶**，建立一個名為 `zeabur-connector` 的 service account。
+3. 進到 **IAM 與管理 → IAM**，點 **授予存取權**，把 `zeabur-connector@<PROJECT_ID>.iam.gserviceaccount.com` 加為主體並賦予 `roles/container.admin` 角色。
+4. 回到 **服務帳戶**，點開 `zeabur-connector`，切到 **權限** 分頁，點 **授予存取權**，把 `zeabur-byos-connector@zeabur-system.iam.gserviceaccount.com` 加為主體並賦予 `roles/iam.serviceAccountTokenCreator` 角色。
+
+</Tabs.Tab>
+<Tabs.Tab>
+
+開啟 [Cloud Shell](https://shell.cloud.google.com/)（或任何已驗證 `gcloud` 的終端機），設定 `PROJECT_ID` 後執行：
+
+```bash
+export PROJECT_ID=your-gcp-project-id
+
+gcloud services enable \
+  container.googleapis.com \
+  cloudresourcemanager.googleapis.com \
+  --project=$PROJECT_ID
+
+gcloud iam service-accounts create zeabur-connector --project=$PROJECT_ID
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:zeabur-connector@$PROJECT_ID.iam.gserviceaccount.com" \
+  --role="roles/container.admin"
+
+gcloud iam service-accounts add-iam-policy-binding \
+  zeabur-connector@$PROJECT_ID.iam.gserviceaccount.com \
+  --member="serviceAccount:zeabur-byos-connector@zeabur-system.iam.gserviceaccount.com" \
+  --role="roles/iam.serviceAccountTokenCreator" \
+  --project=$PROJECT_ID
+```
+
+</Tabs.Tab>
+<Tabs.Tab>
+
+把以下 prompt 貼到 [Claude Code](https://claude.com/claude-code) 或 [Codex CLI](https://github.com/openai/codex)——AI agent 會幫你跑完所有指令並回報你需要的資訊：
+
+```text
+Set up Zeabur BYOS for GKE on a GCP project. Use gcloud (assume I'm authenticated).
+
+1. Ask me which GCP project to use, or create a new one.
+2. Make sure the project is linked to a billing account.
+3. Run these commands (substitute PROJECT_ID):
+   - gcloud services enable container.googleapis.com cloudresourcemanager.googleapis.com --project=PROJECT_ID
+   - gcloud iam service-accounts create zeabur-connector --project=PROJECT_ID
+   - gcloud projects add-iam-policy-binding PROJECT_ID --member="serviceAccount:zeabur-connector@PROJECT_ID.iam.gserviceaccount.com" --role="roles/container.admin"
+   - gcloud iam service-accounts add-iam-policy-binding zeabur-connector@PROJECT_ID.iam.gserviceaccount.com --member="serviceAccount:zeabur-byos-connector@zeabur-system.iam.gserviceaccount.com" --role="roles/iam.serviceAccountTokenCreator" --project=PROJECT_ID
+
+When done, print the project ID and the connector service account email so I can paste them into Zeabur's Bind GCP Service Account form.
+```
+
+</Tabs.Tab>
+</Tabs>
+
+### 將專案綁定到 Zeabur
+
+前往 [https://zeabur.com/account/byos](https://zeabur.com/account/byos)，點擊 **綁定 GCP Service Account**，填入以下資訊後送出：
+
+- **Service Account Email**：`zeabur-connector@<PROJECT_ID>.iam.gserviceaccount.com`
+- **專案 ID**：你的 GCP 專案 ID
+
+### 購買專屬叢集
+
+Service account 綁定完成後，前往[購買叢集](https://zeabur.com/servers/buy-cluster)頁面。你會看到一個新的 provider 選項 **GCP - &lt;專案名稱&gt;**。選它，Zeabur 就會直接在你的 GCP 專案中建立一個新的 GKE 叢集。
+
+</Steps>


### PR DESCRIPTION
## Summary

- Add `byos/gcp.mdx` for all five locales (en-US, zh-TW, zh-CN, ja-JP, es-ES), mirroring the existing AWS BYOS doc structure.
- Offers three setup paths in tabs:
  - **Cloud Console** — manual click-through with direct links to enable the Kubernetes Engine and Cloud Resource Manager APIs.
  - **gcloud CLI** — copy-pasteable script for Cloud Shell.
  - **Claude Code / Codex** — prompt for delegating the whole setup to an AI agent.
- Update each locale's `byos/_meta.ts` to add `gcp: 'GCP'` to the sidebar.

Pairs with [zeabur/dashboard#1457](https://github.com/zeabur/dashboard/pull/1457), which adds the same three-tab guide inside the Bind GCP Service Account modal.

## Test plan

- [ ] Visit `/docs/en-US/byos/gcp` and verify the page renders with all three tabs working
- [ ] Verify GCP appears in the BYOS sidebar next to AWS
- [ ] Click the API enable links — should open the GCP Console API library
- [ ] Spot-check the other locales: zh-TW, zh-CN, ja-JP, es-ES

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GCP added as a BYOS provider option for creating GKE clusters.

* **Documentation**
  * Added comprehensive GCP BYOS guides (EN, ES, JA, ZH‑CN, ZH‑TW) with step‑by‑step setup workflows (console, gcloud, agent) and binding/purchase instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->