### PR TITLE
docs: show Turnstile widget in feedback form (SEI-535)

### DIFF
--- a/docs/components/FeedbackWidget/index.tsx
+++ b/docs/components/FeedbackWidget/index.tsx
@@ -131,7 +131,9 @@ function loadTurnstileScript(): Promise<void> {
   return turnstileLoadPromise
 }
 
-function useTurnstile() {
+type TurnstileSize = 'compact' | 'flexible' | 'normal'
+
+function useTurnstile(size: TurnstileSize) {
   const tokenRef = useRef<string | null>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const widgetIdRef = useRef<string | null>(null)
@@ -144,12 +146,12 @@ function useTurnstile() {
         containerRef.current,
         {
           sitekey: TURNSTILE_SITEKEY,
-          size: 'compact',
+          size,
           callback: (token: string) => { tokenRef.current = token },
         }
       )
     }
-  }, [])
+  }, [size])
 
   const getToken = useCallback(async (): Promise<string | null> => {
     await ensureReady()
@@ -180,7 +182,15 @@ function useTurnstile() {
     }
   }, [])
 
-  return { containerRef, ensureReady, getToken, resetToken }
+  const removeWidget = useCallback(() => {
+    if ((window as any).turnstile && widgetIdRef.current !== null) {
+      ;(window as any).turnstile.remove(widgetIdRef.current)
+    }
+    widgetIdRef.current = null
+    tokenRef.current = null
+  }, [])
+
+  return { containerRef, ensureReady, getToken, resetToken, removeWidget }
 }
 
 /**
@@ -194,7 +204,8 @@ export default function FeedbackWidget({ variant = 'toc' }: { variant?: 'toc' | 
   const t = i18n[locale] || i18n['en-US']
   const ratingLabels = RATING_LABELS[locale] || RATING_LABELS['en-US']
 
-  const { containerRef, ensureReady, getToken, resetToken } = useTurnstile()
+  const turnstileSize: TurnstileSize = variant === 'toc' ? 'compact' : 'flexible'
+  const { containerRef, ensureReady, getToken, resetToken, removeWidget } = useTurnstile(turnstileSize)
 
   const [rating, setRating] = useState<Rating | null>(null)
   const [feedback, setFeedback] = useState('')
@@ -214,11 +225,20 @@ export default function FeedbackWidget({ variant = 'toc' }: { variant?: 'toc' | 
     resetWidget()
   }, [pagePath, resetWidget])
 
+  const formVisible = status === 'expanded' || status === 'submitting' || status === 'error'
+
+  useEffect(() => {
+    if (!formVisible) return
+    ensureReady().catch(() => {})
+    return () => {
+      removeWidget()
+    }
+  }, [formVisible, ensureReady, removeWidget])
+
   const handleRating = (value: Rating) => {
     setRating(value)
     if (status === 'idle') {
       setStatus('expanded')
-      ensureReady().catch(() => {})
     }
   }
 
@@ -330,7 +350,7 @@ export default function FeedbackWidget({ variant = 'toc' }: { variant?: 'toc' | 
         ))}
       </div>
 
-      {(status === 'expanded' || status === 'submitting' || status === 'error') && (
+      {formVisible && (
         <div className="feedback-form">
           <textarea
             className="feedback-textarea"
@@ -340,6 +360,8 @@ export default function FeedbackWidget({ variant = 'toc' }: { variant?: 'toc' | 
             rows={3}
             disabled={status === 'submitting'}
           />
+
+          <div ref={containerRef} className="feedback-turnstile" />
 
           <div className="feedback-actions">
             {status === 'error' && (
@@ -363,8 +385,6 @@ export default function FeedbackWidget({ variant = 'toc' }: { variant?: 'toc' | 
           </div>
         </div>
       )}
-
-      <div ref={containerRef} style={{ display: 'none' }} />
     </div>
   )
 }

--- a/docs/pages/styles.css
+++ b/docs/pages/styles.css
@@ -612,6 +612,10 @@ html.dark .feedback-emoji.active {
 	margin-top: 0.75rem;
 }
 
+.feedback-turnstile {
+	margin-top: 0.75rem;
+}
+
 .feedback-textarea {
 	width: 100%;
 	padding: 0.625rem 0.75rem;


### PR DESCRIPTION
## Summary

- Render the Cloudflare Turnstile widget visibly between the textarea and Send button instead of inside a `display: none` div, so the non-interactive challenge can run reliably across page navigations.
- Use `flexible` size for the inline (mobile/full-width) variant and `compact` for the TOC sidebar variant — the latter avoids forcing the narrow sidebar wider than its natural width.
- Mount/remove the widget with the form via `useEffect` so each open creates a fresh instance and stale tokens never linger across navigations.

## Why

A colleague kept hitting "Turnstile verification failed" when submitting feedback on different doc pages. Root cause was the widget being rendered inside `display: none` while the Cloudflare site was set to Non-interactive mode — a combination Cloudflare doesn't reliably verify, especially after `turnstile.reset()` on page navigation.

## Required Cloudflare config change

For the widget to actually render UI, the Cloudflare Turnstile sitekey's **Widget Mode** must be set to **Non-interactive** (or Managed). If it stays on **Invisible**, the code change is harmless but no widget will appear visually.

## Test plan

- [x] Submit feedback on `/en-US` (root) — succeeds
- [x] Navigate to `/en-US/deploy/how-deploys-work` and submit — succeeds (this was the previously-failing case)
- [x] Submit on `/zh-TW/deploy/methods/dockerfile` — succeeds with localized "感謝您的回饋！"
- [x] Stress test: 4 sequential nav+submit cycles — all succeed
- [ ] After Cloudflare mode flip to Non-interactive: visually confirm widget renders inside the feedback form
- [ ] Verify TOC sidebar (desktop) — compact widget fits without expanding sidebar
- [ ] Verify inline variant (mobile/tablet) — flexible widget fills container width

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved Turnstile verification widget rendering with dynamic sizing
  * Enhanced widget lifecycle management with explicit cleanup handling
  * Optimized form visibility state to control widget initialization timing
  
* **Style**
  * Added spacing adjustments for Turnstile widget element

<!-- end of auto-generated comment: release notes by coderabbit.ai -->