### PR TITLE
docs: skip last-updated regen when no git repo present

### DIFF
--- a/docs/scripts/build-last-updated.mjs
+++ b/docs/scripts/build-last-updated.mjs
@@ -6,16 +6,25 @@ const DOCS_ROOT = path.resolve(import.meta.dirname, '..')
 const PAGES_DIR = path.join(DOCS_ROOT, 'pages')
 const OUT_FILE = path.join(DOCS_ROOT, 'lib', 'last-updated.json')
 
-const GIT_ROOT = execFileSync('git', ['rev-parse', '--show-toplevel'], {
-  cwd: DOCS_ROOT,
-  encoding: 'utf8',
-}).trim()
-
-const IS_SHALLOW =
-  execFileSync('git', ['rev-parse', '--is-shallow-repository'], {
-    cwd: GIT_ROOT,
+let GIT_ROOT = null
+let IS_SHALLOW = false
+try {
+  GIT_ROOT = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+    cwd: DOCS_ROOT,
     encoding: 'utf8',
-  }).trim() === 'true'
+    stdio: ['ignore', 'pipe', 'ignore'],
+  }).trim()
+  IS_SHALLOW =
+    execFileSync('git', ['rev-parse', '--is-shallow-repository'], {
+      cwd: GIT_ROOT,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim() === 'true'
+} catch {
+  // No git available (e.g. Zeabur build container with no .git dir).
+  // Fall through to the same path as a shallow clone: use the committed manifest.
+  GIT_ROOT = null
+}
 
 function walk(dir) {
   const out = []
@@ -62,7 +71,7 @@ const expectedRoutes = files.map(routeFor)
 // but first, verify every current MDX route is covered by the committed
 // manifest. Otherwise a new page added without regenerating the manifest
 // would silently ship without a "Last updated" line.
-if (IS_SHALLOW) {
+if (!GIT_ROOT || IS_SHALLOW) {
   const committed = readCommittedManifest()
   const missingRoutes = expectedRoutes.filter((route) => !committed[route])
   if (missingRoutes.length) {
@@ -76,8 +85,9 @@ if (IS_SHALLOW) {
     }
     console.warn(msg)
   }
+  const reason = !GIT_ROOT ? 'no git repository detected' : 'shallow clone detected'
   console.log(
-    '[last-updated] shallow clone detected — skipping regeneration; using committed manifest',
+    `[last-updated] ${reason} — skipping regeneration; using committed manifest`,
   )
   process.exit(0)
 }


### PR DESCRIPTION
## Summary
- Zeabur's build container has no `.git` directory at all, so `docs/scripts/build-last-updated.mjs` crashed on its unconditional `git rev-parse --show-toplevel` call before the existing shallow-clone fallback could run.
- Wrap git detection in try/catch and treat "no git" the same as a shallow clone: use the committed `lib/last-updated.json` and validate it covers every current MDX route.

## Test plan
- [x] `node scripts/build-last-updated.mjs` in a copy with no `.git` → exits 0, logs "no git repository detected"
- [x] `node scripts/build-last-updated.mjs` in real repo → writes 1260 routes
- [x] Full `pnpm build` succeeds locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/zeabur/pr/741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved build process robustness by adding defensive checks for git repository availability. The build script now gracefully handles environments where git is unavailable, using cached data instead of regenerating timestamps. Enhanced error logging for better visibility into build conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->