### PR TITLE
docs: enforce classification flow for new docs PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# CODEOWNERS — 自動指派 reviewer
+#
+# 規則優先順序：愈靠檔尾的規則愈優先。每個檔案匹配最後一條規則。
+# 無規則匹配的檔案無強制 reviewer。
+#
+# 全文規則見：https://docs.github.com/en/repositories/managing-your-repositories-settings-and-customizations/customizing-your-repository/about-code-owners
+
+# ─── Docs 結構與分類 ──────────────────────────────────────────────────────
+# 為什麼鎖這幾類檔案？
+#  - 頂層 _meta.ts 決定 sidebar L1（separator + L1 目錄名稱），亂改會打破 IA 規則
+#  - audit-docs.sh / docs-audit.yml 是維護者自己的稽核工具，需 Docs Owner 批
+#  - next.config.js 在這個 repo 主要承載 docs redirect（IA 重構時的 301 規則）
+#
+# 文件分類規則見 zebra-manual/docs/docs-maintenance/
+
+docs/pages/**/_meta.ts        @linglingwu005
+docs/scripts/audit-docs.sh    @linglingwu005
+docs/next.config.js           @linglingwu005
+.github/workflows/docs-audit.yml @linglingwu005
+.github/PULL_REQUEST_TEMPLATE.md @linglingwu005

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,49 @@
+<!--
+此 PR template 是 zeabur/zeabur 的預設範本。
+若 PR 內容**未涉及 docs/**，可刪除下方「📚 Docs PRs」區塊後再送出。
+-->
+
+## Summary
+
+<!-- 一句話描述這個 PR 做了什麼。 -->
+
+## Test plan
+
+- [ ] <!-- 列出驗證步驟 -->
+
+---
+
+<details open>
+<summary><b>📚 Docs PRs（如果這個 PR 修改 <code>docs/</code>，必填）</b></summary>
+
+> 文件分類錯誤會連動影響 AI Agent 索引、in-app CTA URL、與使用者搜尋直覺。
+> 完整規則見 [zebra-manual / docs-maintenance](https://github.com/zeabur/zebra-manual/tree/main/docs/docs-maintenance)。
+
+### 分類流程（新增 / 搬移文件必跑）
+
+- [ ] 已用 [`classification-guide.md` §1 決策樹](https://github.com/zeabur/zebra-manual/blob/main/docs/docs-maintenance/classification-guide.md#1-分類決策樹) 確認文件落點
+- [ ] 文件歸屬於**單一** Diátaxis 象限（Tutorial / How-to / Reference / Explanation）
+- [ ] 確認**沒有**新增 L1 目錄；如果有，已在下方說明理由並 tag Docs Owner（@linglingwu05）
+
+### 5 語系一致性
+
+- [ ] `.mdx` 同時建立在 `en-US` 與 `zh-TW`
+- [ ] **5 個語系**的 `_meta.ts` 都已同步更新（en-US / zh-TW / zh-CN / ja-JP / es-ES）— 即使尚未翻譯，key 必須先建立
+- [ ] 圖片放在 `docs/public/{section}/`
+
+### 搬移 / 重新命名（適用時勾選）
+
+- [ ] `next.config.js` 已加 301 redirect（含 `/:locale/` 變體）
+- [ ] 舊位置在所有 5 個語系標記 `{ display: 'hidden' }`
+- [ ] `grep -rn '舊路徑' docs/pages/ --include='*.mdx'` 已確認無殘留內部連結
+
+### 驗證
+
+- [ ] `cd docs && pnpm dev` — 本地確認側欄位置正確、內容渲染正常
+- [ ] `cd docs && bash scripts/audit-docs.sh` — 通過審計（CI 也會自動跑）
+
+### 分類決策說明（如果是新增 / 搬移文件）
+
+<!-- 簡述：為什麼放在這個位置？走完決策樹哪一條路徑？ -->
+
+</details>

--- a/docs/scripts/audit-docs.sh
+++ b/docs/scripts/audit-docs.sh
@@ -6,14 +6,19 @@
 PAGES="pages"
 LOCALES=(en-US zh-TW zh-CN ja-JP es-ES)
 REF=en-US
-ISSUES=0
+
+# Issues are counted via a temp file because most checks below run inside
+# subshells (created by pipelines), so a plain shell variable would not
+# propagate counts back to the parent shell.
+ISSUE_FILE=$(mktemp)
+trap 'rm -f "$ISSUE_FILE"' EXIT
 
 red()   { printf "\033[31m%s\033[0m\n" "$*"; }
 green() { printf "\033[32m%s\033[0m\n" "$*"; }
 yellow(){ printf "\033[33m%s\033[0m\n" "$*"; }
 bold()  { printf "\033[1m%s\033[0m\n" "$*"; }
 
-issue() { yellow "  $*"; ISSUES=$((ISSUES+1)); }
+issue() { yellow "  $*"; echo "x" >> "$ISSUE_FILE"; }
 
 # ─── 1. _meta.ts 跨語系結構一致性 ───────────────────────────────────────────
 bold "═══ 1. _meta.ts 跨語系 visible keys 一致性（基準：$REF）═══"
@@ -121,8 +126,10 @@ done
 
 # ─── Summary ────────────────────────────────────────────────────────────────
 bold ""
+ISSUES=$(wc -l < "$ISSUE_FILE" | tr -d ' ')
 if [ "$ISSUES" -gt 0 ]; then
   red "══ 發現 $ISSUES 個問題 ══"
+  exit 1
 else
   green "══ 全部通過 ══"
 fi


### PR DESCRIPTION
## Summary

讓所有改 `docs/` 的 PR 都自動跑 [zebra-manual / docs-maintenance](https://github.com/zeabur/zebra-manual/tree/main/docs/docs-maintenance) 的分類流程，避免再次出現像最近 `team` / `byos` 那種 L2 內容直接被當 L1 放到頂層的情況。

三層治理（這個 PR）：

1. **PR template**（`.github/PULL_REQUEST_TEMPLATE.md`）— 改到 `docs/` 的 PR 必填分類 checklist，連結到 zebra-manual 的決策樹、5 語系一致性、redirect 規則
2. **CODEOWNERS**（`.github/CODEOWNERS`）— 頂層 `_meta.ts`、`audit-docs.sh`、`next.config.js`、PR template 自身、即將加上的 docs-audit workflow，這幾類結構性檔案需要 Docs Owner（@linglingwu005）審核
3. **audit-docs.sh fix**（`docs/scripts/audit-docs.sh`）— 原本因為 `while read` 在 subshell 裡，`ISSUES` 計數不會傳回 parent shell，所以 script 永遠 exit 0。改用 temp file 計數，現在會在有 issues 時 `exit 1`，CI 才有得擋

## CI workflow（待加）

CI workflow 沒在這個 PR 裡，因為我這邊的 OAuth token 缺 `workflow` scope，push 被 GitHub 擋掉了。請維護者其中一位執行其中一種方式：

**A. 直接加檔**：在這個 branch（`canyugs:docs/enforce-classification-flow`）建 `.github/workflows/docs-audit.yml`，內容如下：

```yaml
name: Docs Audit

on:
  pull_request:
    paths:
      - 'docs/pages/**'
      - 'docs/scripts/audit-docs.sh'
      - 'docs/next.config.js'

permissions:
  contents: read
  pull-requests: write

jobs:
  audit:
    name: audit-docs.sh (no new issues vs base)
    runs-on: ubuntu-latest
    steps:
      - name: Checkout PR head
        uses: actions/checkout@v4
        with:
          fetch-depth: 0

      - name: Run audit on base ref
        id: base
        run: |
          set +e
          git checkout "${{ github.event.pull_request.base.sha }}" -- docs/
          cd docs
          bash scripts/audit-docs.sh > /tmp/base-audit.log 2>&1
          BASE_COUNT=$(grep -oE '發現 [0-9]+ 個問題' /tmp/base-audit.log | grep -oE '[0-9]+' || echo 0)
          [ -z "$BASE_COUNT" ] && BASE_COUNT=0
          echo "count=$BASE_COUNT" >> "$GITHUB_OUTPUT"
          echo "Base ($GITHUB_BASE_REF): $BASE_COUNT issues"

      - name: Run audit on PR head
        id: head
        run: |
          set +e
          git checkout "${{ github.event.pull_request.head.sha }}" -- docs/
          cd docs
          bash scripts/audit-docs.sh > /tmp/head-audit.log 2>&1
          HEAD_COUNT=$(grep -oE '發現 [0-9]+ 個問題' /tmp/head-audit.log | grep -oE '[0-9]+' || echo 0)
          [ -z "$HEAD_COUNT" ] && HEAD_COUNT=0
          echo "count=$HEAD_COUNT" >> "$GITHUB_OUTPUT"
          echo "Head: $HEAD_COUNT issues"

      - name: Compare and report
        env:
          BASE: ${{ steps.base.outputs.count }}
          HEAD: ${{ steps.head.outputs.count }}
          GH_TOKEN: ${{ github.token }}
          PR_NUMBER: ${{ github.event.pull_request.number }}
          REPO: ${{ github.repository }}
        run: |
          set -e
          DELTA=$((HEAD - BASE))

          {
            echo "## 📚 Docs Audit"
            echo ""
            echo "| | Base (\`$GITHUB_BASE_REF\`) | This PR | Δ |"
            echo "|---|---|---|---|"
            echo "| Issues | $BASE | $HEAD | $DELTA |"
            echo ""
            if [ "$DELTA" -gt 0 ]; then
              echo "> ❌ **此 PR 引入了 $DELTA 個新的審計問題。** 詳見下方 head log。"
              echo ""
              echo "### 分類流程提醒"
              echo "請對照 [zebra-manual / classification-guide](https://github.com/zeabur/zebra-manual/blob/main/docs/docs-maintenance/classification-guide.md) 的決策樹確認分類，並修正 \`_meta.ts\` 跨語系一致性問題。"
              echo ""
              echo "<details><summary>Head audit log（引入新問題）</summary>"
              echo ""
              echo '```'
              # Strip ANSI color codes for readability in GitHub comment
              sed 's/\x1B\[[0-9;]*[a-zA-Z]//g' /tmp/head-audit.log | tail -200
              echo '```'
              echo "</details>"
            elif [ "$DELTA" -lt 0 ]; then
              echo "> ✅ 此 PR 修復了 $((-DELTA)) 個問題，感謝改善！"
            else
              echo "> ✅ 此 PR 未引入新的審計問題。"
            fi
          } > /tmp/comment.md

          # Upsert PR comment (one per PR, marked with hidden tag for idempotency)
          MARKER='<!-- docs-audit-bot -->'
          {
            echo "$MARKER"
            cat /tmp/comment.md
          } > /tmp/full-comment.md

          EXISTING_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" | head -1)
          if [ -n "$EXISTING_ID" ]; then
            gh api --method PATCH "repos/$REPO/issues/comments/$EXISTING_ID" -F body=@/tmp/full-comment.md
          else
            gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/full-comment.md
          fi

          if [ "$DELTA" -gt 0 ]; then
            echo "::error::此 PR 引入了 $DELTA 個新的 docs 審計問題。請先修正再合併。"
            exit 1
          fi
```

**B. 我重新跑**：給我 `workflow` scope（`gh auth refresh -s workflow`），我把 workflow push 上來。

### Workflow 行為

- Trigger：PR 改到 `docs/pages/**`、`docs/scripts/audit-docs.sh`、`docs/next.config.js`
- 跑 audit 在 base（`main`）和 head 兩邊，比對 issue 數
- **只在 head > base 時 fail**（不會被現有的 304 個既存 issue 擋住），並把 head log 貼成 PR comment
- Comment 用 hidden marker idempotent upsert，不會重複貼

## Test plan

- [ ] PR template 在 `gh pr create` 介面 / web UI 自動帶入
- [ ] CODEOWNERS 觸發 @linglingwu005 自動 review request（測：改 `docs/pages/en-US/_meta.ts` 開測試 PR）
- [ ] `bash docs/scripts/audit-docs.sh` 本地跑：本 PR 的 base 應該是 304 issues、exit 1（已驗證）
- [ ] CI workflow 加入後，故意在 `_meta.ts` 製造一個新 drift → 觀察 comment + fail
- [ ] CI workflow 加入後，乾淨 PR → comment 顯示 Δ=0 + pass

## 後續

`team` / `byos` / `cluster` 等實際分類錯位的修正不在這個 PR 裡，會用另外的 ticket 追。

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/zeabur/pr/749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed documentation audit script to correctly track and report all detected issues.

* **Chores**
  * Added code ownership configuration for documentation paths.
  * Added pull request template with documentation contribution guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->