### PR TITLE
docs: redirect bare /marketplace to template catalog (SEI-604)

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -53,6 +53,19 @@ export default withNextra({
     }).flat();
 
     return templateRedirectsRule.concat([
+      // Bare /marketplace path -> public template catalog (matches the
+      // existing per-template redirects above, which already point to
+      // zeabur.com/templates/<code>).
+      {
+        source: '/marketplace',
+        destination: 'https://zeabur.com/templates',
+        permanent: true,
+      },
+      {
+        source: '/:locale/marketplace',
+        destination: 'https://zeabur.com/:locale/templates',
+        permanent: true,
+      },
       {
         source: '/guides/go/go',
         destination: '/guides/go',


### PR DESCRIPTION
## Summary

The bare `/marketplace` path returned 404 in production across all 5 locales. Per-template redirects already point at `zeabur.com/templates/<code>`; the bare path now redirects to the same catalog so external links (search engines, blog posts, "marketplace" CTAs) land on a real page instead of 404.

Linear: [SEI-604](https://linear.app/zeabur/issue/SEI-604)

```js
{ source: '/marketplace',         destination: 'https://zeabur.com/templates', permanent: true },
{ source: '/:locale/marketplace', destination: 'https://zeabur.com/:locale/templates', permanent: true },
```

Locale is preserved to match the per-template redirect convention (`zeabur.com/:locale/templates/<code>`). Picked **Option C** from the Linear ticket — the user-facing template catalog lives on the marketing site, not docs.

## Test plan

- [x] All 5 locales `/marketplace` → 308 → `zeabur.com/<locale>/templates` (200)
- [x] Bare `/marketplace` → 308 → `zeabur.com/templates` (200)
- [x] Per-template redirects (`/marketplace/dragonfly`, `/en-US/marketplace/n8n`, etc.) unchanged and still resolve
- [ ] CodeRabbit review passes

## Related

- Sibling cleanups: [SEI-602 / PR #752](https://github.com/zeabur/zeabur/pull/752), [SEI-603](https://linear.app/zeabur/issue/SEI-603), [SEI-605](https://linear.app/zeabur/issue/SEI-605)
- Pattern parents: PR [#747](https://github.com/zeabur/zeabur/pull/747), [#748](https://github.com/zeabur/zeabur/pull/748)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/zeabur/pr/753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated URL redirects to point marketplace paths to templates page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->