### PR TITLE
fix(seo): safe redirects and clean sitemap for GSC issues

### DIFF
--- a/docs/middleware.ts
+++ b/docs/middleware.ts
@@ -31,6 +31,15 @@ function findCanonicalLocale(segment: string): string | undefined {
   return locales.find(l => l.toLowerCase() === segment.toLowerCase())
 }
 
+// Redirect using a relative path in the Location header to prevent the
+// internal service hostname (e.g. nextra-v2.zeabur.internal) from leaking
+// through the rewrite proxy — which causes Google "Redirect error".
+function safeRedirect(request: NextRequest, relativePath: string) {
+  const response = NextResponse.redirect(new URL(relativePath, request.url))
+  response.headers.set('Location', relativePath)
+  return response
+}
+
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
 
@@ -46,7 +55,7 @@ export function middleware(request: NextRequest) {
       if (canonical) {
         const rest = pathname.slice(segment.length + 1) // +1 for leading slash
         const url = addBasePath(`/${canonical}${rest}${request.nextUrl.search}`)
-        return NextResponse.redirect(new URL(url, request.url))
+        return safeRedirect(request, url)
       }
     }
   }
@@ -58,7 +67,7 @@ export function middleware(request: NextRequest) {
     const url = addBasePath(`/${locale}${pathname}`)
     // e.g. incoming request is /products
     // The new URL is now /en-US/products
-    return NextResponse.redirect(new URL(url, request.url))
+    return safeRedirect(request, url)
   }
 
   const [, requestLocale] = pathname.split('/', 2)

--- a/docs/sitemap.js
+++ b/docs/sitemap.js
@@ -40,11 +40,16 @@ async function getRedirectSources() {
   return sources;
 }
 
+function escapeRegex(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 // Check if a docs-relative path (e.g. /en-US/billing/plans) is a redirect source
 function isRedirected(docsPath, redirectSources) {
   for (const pattern of redirectSources) {
     if (pattern.includes('.+')) {
-      const re = new RegExp(`^${pattern}$`);
+      const escaped = pattern.split('.+').map(escapeRegex).join('.+');
+      const re = new RegExp(`^${escaped}$`);
       if (re.test(docsPath)) return true;
     } else if (docsPath === pattern) {
       return true;

--- a/docs/sitemap.js
+++ b/docs/sitemap.js
@@ -5,33 +5,53 @@ const baseUrl = "https://zeabur.com/docs";
 const pagesDir = "./pages";
 const publicDir = "./public";
 
-// Marketplace templates from next.config.js
-const templateDocsMap = {
-  'dragonfly': 'UKMPPL',
-  'flowise': '2JYZTR',
-  'focalboard': 'SU7RTR',
-  'ghost': 'SHEU50',
-  'halo': 'Q6H2MA',
-  'likit': 'KZOLHA',
-  'linkwarden': '1E5ABT',
-  'logto': 'AV1NZ4',
-  'memos': 'KIJROJ',
-  'mongodb': 'KXL04P',
-  'mysql': 'DGLGRG',
-  'n8n': 'W2H4RW',
-  'postgresql': 'B20CX0',
-  'rabbitmq': 'QAQWVO',
-  'redis': 'KQZHXT',
-  'rsshub': 'X46PTP',
-  'ttrss': 'F1A1Y2',
-  'umami': '01NQCC',
-  'uptime-kuma': 'Q764RP',
-  'wewe-rss': 'DI9BBD',
-  'wordpress': 'CV344X',
-};
-
 // Supported locales
 const locales = ['en-US', 'zh-TW', 'zh-CN', 'ja-JP', 'es-ES'];
+
+// Build a set of redirect source paths from next.config.js so the sitemap
+// never advertises URLs that just redirect — Google should discover the
+// canonical destination directly.
+async function getRedirectSources() {
+  const configModule = await import('./next.config.js');
+  const config = configModule.default;
+  const redirects = typeof config.redirects === 'function'
+    ? await config.redirects()
+    : [];
+
+  const sources = new Set();
+  for (const rule of redirects) {
+    // Convert Next.js patterns like /:locale/billing/plans to a regex.
+    // Replace :locale with each real locale, :path* with .+
+    const pattern = rule.source;
+
+    if (pattern.includes(':locale')) {
+      for (const locale of locales) {
+        const concrete = pattern
+          .replace(':locale', locale)
+          .replace(/:path\*/g, '.+');
+        sources.add(concrete);
+      }
+    } else {
+      const concrete = pattern.replace(/:path\*/g, '.+');
+      sources.add(concrete);
+    }
+  }
+
+  return sources;
+}
+
+// Check if a docs-relative path (e.g. /en-US/billing/plans) is a redirect source
+function isRedirected(docsPath, redirectSources) {
+  for (const pattern of redirectSources) {
+    if (pattern.includes('.+')) {
+      const re = new RegExp(`^${pattern}$`);
+      if (re.test(docsPath)) return true;
+    } else if (docsPath === pattern) {
+      return true;
+    }
+  }
+  return false;
+}
 
 // Recursively get all .mdx files in a directory
 const getFiles = (dir) => {
@@ -48,30 +68,30 @@ const getFiles = (dir) => {
   return files;
 };
 
+const redirectSources = await getRedirectSources();
 const files = getFiles(pagesDir);
 
-// Create sitemap.xml
 let sitemap = '<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n';
 
-// Add all pages from .mdx files
+let included = 0;
+let excluded = 0;
+
 for (let file of files) {
   const fileName = path.basename(file);
   const pageName = fileName.split(".")[0];
   const fileDir = path.dirname(file);
-  const url = `${baseUrl}${fileDir.replace(/^pages/, "")}${pageName === "index" ? "" : `/${pageName}`}`;
-  sitemap += `  <url>\n    <loc>${url}</loc>\n  </url>\n`;
-}
+  const docsPath = `${fileDir.replace(/^pages/, "")}${pageName === "index" ? "" : `/${pageName}`}`;
 
-// Add marketplace URLs for all locales
-for (let locale of locales) {
-  for (let template of Object.keys(templateDocsMap)) {
-    const url = `${baseUrl}/${locale}/marketplace/${template}`;
-    sitemap += `  <url>\n    <loc>${url}</loc>\n  </url>\n`;
+  if (isRedirected(docsPath, redirectSources)) {
+    excluded++;
+    continue;
   }
+
+  sitemap += `  <url>\n    <loc>${baseUrl}${docsPath}</loc>\n  </url>\n`;
+  included++;
 }
 
 sitemap += "</urlset>";
 
-// Write sitemap.xml to public directory
 fs.writeFileSync(path.join(publicDir, "sitemap.xml"), sitemap);
-console.log("Sitemap generated!");
+console.log(`Sitemap generated! ${included} URLs included, ${excluded} redirect sources excluded.`);


### PR DESCRIPTION
## Summary

Fixes Google Search Console issues for zeabur.com/docs (DES-635).

- **Middleware redirect leak**: `NextResponse.redirect(new URL(url, request.url))` uses the internal service hostname (`nextra-v2.zeabur.internal`) in the `Location` header. When the rewrite proxy intermittently fails to rewrite it, Googlebot gets an unreachable URL → "Redirect error" in GSC. New `safeRedirect()` helper forces a relative path in the `Location` header.
- **Sitemap stale URLs**: the sitemap generator scanned all `.mdx` files including old ones with redirect rules, causing Google to repeatedly crawl 576 redirect URLs. Now auto-imports redirect rules from `next.config.js` and excludes matching URLs at build time.

## Test plan

- [ ] Run `node sitemap.js` — verify excluded count > 0 and no redirect source URLs in output
- [ ] Verify `/docs/operations/resources/scaling` redirect `Location` header is a relative path (not absolute with internal hostname)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/zeabur/pr/769"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781954357&installation_id=128583772&pr_number=769&repository=zeabur%2Fzeabur&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fzeabur%2Fpull%2F769&signature=9f4f3599fef8d3a3ce1432f3d9af098ef890c4b229dbe25f6c357ed4905f1b1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->