### PR TITLE
docs(ai-hub): add usage and cost guide in 5 locales (PLA-1616)

### DIFF
--- a/docs/pages/en-US/ai-hub/_meta.ts
+++ b/docs/pages/en-US/ai-hub/_meta.ts
@@ -1,4 +1,5 @@
 export default {
   'n8n-integration': 'n8n Integration',
   'sillytavern-integration': 'SillyTavern Integration',
+  'usage-and-cost': 'Reading Usage and Cost',
 }

--- a/docs/pages/en-US/ai-hub/usage-and-cost.mdx
+++ b/docs/pages/en-US/ai-hub/usage-and-cost.mdx
@@ -1,0 +1,147 @@
+---
+title: Reading Usage and Cost
+ogImageTitle: Reading Usage and Cost
+ogImageSubtitle: Read tokens and cost from response headers and the usage object
+---
+
+import { Callout } from 'nextra/components'
+
+# Reading Usage and Cost
+
+Every successful AI Hub response carries two things you usually need: how many tokens were consumed, and how much the request cost. This page shows where they live so you can wire them into dashboards, set per-user budgets, or just sanity-check pricing as you experiment.
+
+## Two ways to get the data
+
+| Source | What you get | Best for |
+| --- | --- | --- |
+| Response headers | Cost in USD, key spend so far, call ID | Fastest — no body parsing |
+| Response body `usage` | Tokens, prompt cache breakdown, reasoning tokens | Same place the OpenAI SDK looks |
+
+You don't have to choose — every successful response has both.
+
+## Reading the headers
+
+Every response includes a set of headers prefixed with `x-litellm-`:
+
+| Header | Meaning |
+| --- | --- |
+| `x-litellm-response-cost` | USD cost of this request, as a float |
+| `x-litellm-key-spend` | Total USD spent by this API key so far |
+| `x-litellm-call-id` | Per-request ID, useful for support and tracing |
+| `x-litellm-model-id` | Internal model deployment ID |
+| `x-litellm-model-group` | The public model name you requested |
+
+### curl
+
+```bash
+curl -i https://hnd1.aihub.zeabur.ai/v1/chat/completions \
+  -H "Authorization: Bearer YOUR_ZEABUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "claude-sonnet-4-5",
+    "messages": [{"role": "user", "content": "Hello"}],
+    "max_tokens": 32
+  }'
+```
+
+The `-i` flag prints the response headers — look for the `x-litellm-response-cost` line.
+
+### Python
+
+The official OpenAI SDK does not expose response headers to user code by default. If you need cost out of the headers, drop down to `httpx`:
+
+```python
+import httpx
+
+r = httpx.post(
+    "https://hnd1.aihub.zeabur.ai/v1/chat/completions",
+    headers={"Authorization": "Bearer YOUR_ZEABUR_API_KEY"},
+    json={
+        "model": "claude-sonnet-4-5",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "max_tokens": 32,
+    },
+    timeout=60.0,
+)
+print("cost (USD):", r.headers.get("x-litellm-response-cost"))
+print("usage:", r.json()["usage"])
+```
+
+## Reading the body `usage` object
+
+The response body's `usage` object is OpenAI-compatible. For Anthropic and OpenAI models, extra fields appear when relevant:
+
+```json
+{
+  "usage": {
+    "prompt_tokens": 1024,
+    "completion_tokens": 256,
+    "total_tokens": 1280,
+    "prompt_tokens_details": {
+      "cached_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0
+    },
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0
+  }
+}
+```
+
+| Field | Models | Meaning |
+| --- | --- | --- |
+| `prompt_tokens` / `completion_tokens` / `total_tokens` | All | Standard OpenAI fields |
+| `prompt_tokens_details.cached_tokens` | OpenAI | Portion of `prompt_tokens` served from prompt cache — already counted inside `prompt_tokens` |
+| `cache_creation_input_tokens` | Anthropic | Tokens written into Anthropic's prompt cache on this request |
+| `cache_read_input_tokens` | Anthropic | Tokens read back from Anthropic's prompt cache |
+| `completion_tokens_details.reasoning_tokens` | Reasoning models (e.g. `gpt-5`, `gpt-5-mini`) | Tokens spent on internal reasoning |
+
+<Callout>
+  Anthropic and OpenAI count cached tokens differently. Anthropic's `cache_creation_input_tokens` and `cache_read_input_tokens` are reported **outside** `prompt_tokens`. OpenAI's `cached_tokens` is **a subset of** `prompt_tokens`. The body shows both shapes faithfully — pick the field that matches the provider you called.
+</Callout>
+
+## Streaming responses
+
+When you stream, the `usage` object only appears in a final chunk if you opt in. Set `stream_options.include_usage: true` in the request:
+
+```python
+import httpx, json
+
+with httpx.stream(
+    "POST",
+    "https://hnd1.aihub.zeabur.ai/v1/chat/completions",
+    headers={"Authorization": "Bearer YOUR_ZEABUR_API_KEY"},
+    json={
+        "model": "claude-sonnet-4-5",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "max_tokens": 32,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    },
+    timeout=60.0,
+) as r:
+    final_usage = None
+    for line in r.iter_lines():
+        if not line.startswith("data: "):
+            continue
+        payload = line[len("data: "):]
+        if payload == "[DONE]":
+            break
+        chunk = json.loads(payload)
+        if chunk.get("usage"):
+            final_usage = chunk["usage"]
+        # ...your existing token-by-token handling...
+    print("final usage:", final_usage)
+```
+
+Without `stream_options.include_usage`, the streaming response carries no `usage` object at all.
+
+## Historical usage
+
+For per-day totals and a searchable log of every call, use the AI Hub page on the [Zeabur Dashboard](https://zeabur.com/projects). The headers and body fields above are for in-process accounting; the Dashboard is for after-the-fact inspection.
+
+## Related
+
+- [Using Zeabur AI Hub in n8n](./n8n-integration)
+- [Using Zeabur AI Hub in SillyTavern](./sillytavern-integration)

--- a/docs/pages/en-US/ai-hub/usage-and-cost.mdx
+++ b/docs/pages/en-US/ai-hub/usage-and-cost.mdx
@@ -137,6 +137,32 @@ with httpx.stream(
 
 Without `stream_options.include_usage`, the streaming response carries no `usage` object at all.
 
+## Tracing a specific call
+
+To investigate a particular request after the fact — for example, when diagnosing an unexpected response, reconciling a charge, or correlating with application-side logs — use the **completion ID** returned in the response body as `id`:
+
+```python
+resp = client.chat.completions.create(...)
+print("request id:", resp.id)
+# chatcmpl-715764bf-675d-4d95-bbdc-80c037c8ce3f
+```
+
+<Callout type="warning">
+  Always use `response.id`. Do **not** use the `x-litellm-call-id` header — that value is an internal trace identifier used during request routing and is not persisted to spend logs, so lookups by it will yield no result.
+</Callout>
+
+In the [Zeabur Dashboard](https://zeabur.com/projects), open the AI Hub page, expand the relevant daily spend log, and click the info icon on any row. The detail dialog displays the Request ID alongside a copy action; this value is identical to `response.id`.
+
+### Cache-served responses carry a derived suffix
+
+When LiteLLM serves an entire response from its response cache (indicated by a "served from cache" badge in the Dashboard and `cost = 0`), the recorded ID is the original ID with a `_cache_hit<timestamp>` suffix appended:
+
+```
+chatcmpl-2ec370dd-83a6-41b4-817c-1646c57034bc_cache_hit1779350469.4126954
+```
+
+The original request and the cache-served replay are recorded as separate entries in the spend log, sharing the underlying UUID prefix. This allows aggregation by prefix to determine how many times a given prompt was served from cache.
+
 ## Historical usage
 
 For per-day totals and a searchable log of every call, use the AI Hub page on the [Zeabur Dashboard](https://zeabur.com/projects). The headers and body fields above are for in-process accounting; the Dashboard is for after-the-fact inspection.

--- a/docs/pages/es-ES/ai-hub/_meta.ts
+++ b/docs/pages/es-ES/ai-hub/_meta.ts
@@ -1,4 +1,5 @@
 export default {
   "n8n-integration": "Integración con n8n",
-  "sillytavern-integration": "Integración con SillyTavern"
+  "sillytavern-integration": "Integración con SillyTavern",
+  "usage-and-cost": "Leer el uso y el costo"
 }

--- a/docs/pages/es-ES/ai-hub/usage-and-cost.mdx
+++ b/docs/pages/es-ES/ai-hub/usage-and-cost.mdx
@@ -1,0 +1,147 @@
+---
+title: Leer el uso y el costo
+ogImageTitle: Leer el uso y el costo
+ogImageSubtitle: Lea tokens y costo desde los headers de respuesta y el objeto usage
+---
+
+import { Callout } from 'nextra/components'
+
+# Leer el uso y el costo
+
+Cada respuesta exitosa de Zeabur AI Hub trae dos datos que normalmente le interesan: cuántos tokens se consumieron y cuánto costó la solicitud. Esta página le muestra dónde encontrarlos para que pueda conectarlos a sus propios paneles, aplicar límites de presupuesto por usuario o simplemente verificar los precios mientras desarrolla.
+
+## Dos maneras de obtener los datos
+
+| Origen | Qué contiene | Cuándo conviene |
+| --- | --- | --- |
+| Headers de respuesta | Costo en USD, gasto acumulado de la clave, Call ID | Más rápido; no requiere parsear el body |
+| Objeto `usage` del body | Tokens, desglose de caché de prompt, tokens de razonamiento | El mismo lugar donde lee el SDK de OpenAI |
+
+Cada respuesta exitosa trae ambos, así que no tiene que elegir: use el que encaje mejor con su código.
+
+## Leer los headers
+
+Cada respuesta incluye un conjunto de headers con el prefijo `x-litellm-`:
+
+| Header | Significado |
+| --- | --- |
+| `x-litellm-response-cost` | Costo en USD de esta solicitud (float) |
+| `x-litellm-key-spend` | Gasto acumulado en USD de esta clave API hasta ahora |
+| `x-litellm-call-id` | Identificador único de la solicitud, útil para soporte y trazabilidad |
+| `x-litellm-model-id` | ID interno del despliegue del modelo |
+| `x-litellm-model-group` | El nombre público del modelo que pidió |
+
+### curl
+
+```bash
+curl -i https://hnd1.aihub.zeabur.ai/v1/chat/completions \
+  -H "Authorization: Bearer YOUR_ZEABUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "claude-sonnet-4-5",
+    "messages": [{"role": "user", "content": "Hola"}],
+    "max_tokens": 32
+  }'
+```
+
+La opción `-i` imprime los headers de la respuesta — busque la línea `x-litellm-response-cost`.
+
+### Python
+
+El SDK oficial de OpenAI no expone los headers de respuesta al código de usuario. Si necesita el costo desde los headers, use `httpx` directamente:
+
+```python
+import httpx
+
+r = httpx.post(
+    "https://hnd1.aihub.zeabur.ai/v1/chat/completions",
+    headers={"Authorization": "Bearer YOUR_ZEABUR_API_KEY"},
+    json={
+        "model": "claude-sonnet-4-5",
+        "messages": [{"role": "user", "content": "Hola"}],
+        "max_tokens": 32,
+    },
+    timeout=60.0,
+)
+print("costo (USD):", r.headers.get("x-litellm-response-cost"))
+print("usage:", r.json()["usage"])
+```
+
+## Leer el objeto `usage` del body
+
+El objeto `usage` en el body sigue el formato de OpenAI. Para modelos de Anthropic y OpenAI aparecen campos adicionales cuando corresponde:
+
+```json
+{
+  "usage": {
+    "prompt_tokens": 1024,
+    "completion_tokens": 256,
+    "total_tokens": 1280,
+    "prompt_tokens_details": {
+      "cached_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0
+    },
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0
+  }
+}
+```
+
+| Campo | Modelos | Significado |
+| --- | --- | --- |
+| `prompt_tokens` / `completion_tokens` / `total_tokens` | Todos | Campos estándar de OpenAI |
+| `prompt_tokens_details.cached_tokens` | OpenAI | Porción de `prompt_tokens` servida desde la caché de prompt — ya contada dentro de `prompt_tokens` |
+| `cache_creation_input_tokens` | Anthropic | Tokens escritos en la caché de prompt de Anthropic en esta solicitud |
+| `cache_read_input_tokens` | Anthropic | Tokens leídos desde la caché de prompt de Anthropic en esta solicitud |
+| `completion_tokens_details.reasoning_tokens` | Modelos de razonamiento (p. ej. `gpt-5`, `gpt-5-mini`) | Tokens consumidos en el razonamiento interno |
+
+<Callout>
+  Anthropic y OpenAI cuentan los tokens en caché de forma distinta. Los `cache_creation_input_tokens` y `cache_read_input_tokens` de Anthropic se reportan **fuera** de `prompt_tokens`. El `cached_tokens` de OpenAI es **un subconjunto** de `prompt_tokens`. El body devuelve cada formato tal cual lo entrega el proveedor — use el campo que corresponda al modelo que invocó.
+</Callout>
+
+## Respuestas en streaming
+
+En modo streaming, el objeto `usage` solo aparece en un chunk final si lo habilita explícitamente. Agregue `stream_options.include_usage: true` a la solicitud:
+
+```python
+import httpx, json
+
+with httpx.stream(
+    "POST",
+    "https://hnd1.aihub.zeabur.ai/v1/chat/completions",
+    headers={"Authorization": "Bearer YOUR_ZEABUR_API_KEY"},
+    json={
+        "model": "claude-sonnet-4-5",
+        "messages": [{"role": "user", "content": "Hola"}],
+        "max_tokens": 32,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    },
+    timeout=60.0,
+) as r:
+    final_usage = None
+    for line in r.iter_lines():
+        if not line.startswith("data: "):
+            continue
+        payload = line[len("data: "):]
+        if payload == "[DONE]":
+            break
+        chunk = json.loads(payload)
+        if chunk.get("usage"):
+            final_usage = chunk["usage"]
+        # ...su procesamiento de chunks existente...
+    print("usage final:", final_usage)
+```
+
+Sin `stream_options.include_usage`, la respuesta en streaming no incluye ningún objeto `usage`.
+
+## Historial de uso
+
+Para totales por día y un registro consultable de cada solicitud, use la página AI Hub en el [Zeabur Dashboard](https://zeabur.com/projects). Los headers y campos del body que vimos aquí son para contabilidad en tiempo real dentro de su código; el Dashboard es para inspección posterior.
+
+## Enlaces relacionados
+
+- [Usar Zeabur AI Hub en n8n](./n8n-integration)
+- [Usar Zeabur AI Hub en SillyTavern](./sillytavern-integration)

--- a/docs/pages/es-ES/ai-hub/usage-and-cost.mdx
+++ b/docs/pages/es-ES/ai-hub/usage-and-cost.mdx
@@ -137,6 +137,32 @@ with httpx.stream(
 
 Sin `stream_options.include_usage`, la respuesta en streaming no incluye ningún objeto `usage`.
 
+## Rastrear una solicitud específica
+
+Para investigar una solicitud concreta a posteriori — por ejemplo, para diagnosticar una respuesta inesperada, conciliar un cargo o correlacionarla con los registros de su aplicación — utilice el **ID de la completación** devuelto en el body de la respuesta como `id`:
+
+```python
+resp = client.chat.completions.create(...)
+print("request id:", resp.id)
+# chatcmpl-715764bf-675d-4d95-bbdc-80c037c8ce3f
+```
+
+<Callout type="warning">
+  Utilice siempre `response.id`. **No** utilice el header `x-litellm-call-id`: ese valor es un identificador de traza interno utilizado durante el enrutamiento de la solicitud y no se persiste en los spend logs, por lo que cualquier búsqueda por dicho valor no devolverá resultados.
+</Callout>
+
+En el [Zeabur Dashboard](https://zeabur.com/projects), abra la página de AI Hub, despliegue el log diario correspondiente y haga clic en el icono de información de cualquier fila. El diálogo de detalles muestra el Request ID junto con un botón de copia; este valor coincide exactamente con `response.id`.
+
+### Las respuestas servidas desde caché incluyen un sufijo derivado
+
+Cuando LiteLLM sirve una respuesta completa desde su caché de respuestas (lo cual se indica mediante la etiqueta "servido desde caché" en el Dashboard y `cost = 0`), el ID registrado corresponde al ID original con un sufijo `_cache_hit<timestamp>` adjunto:
+
+```
+chatcmpl-2ec370dd-83a6-41b4-817c-1646c57034bc_cache_hit1779350469.4126954
+```
+
+La solicitud original y la respuesta servida desde caché se registran como entradas independientes en el spend log, compartiendo el mismo prefijo de UUID. Esto permite agregar por prefijo para contabilizar cuántas veces una solicitud determinada fue servida desde la caché.
+
 ## Historial de uso
 
 Para totales por día y un registro consultable de cada solicitud, use la página AI Hub en el [Zeabur Dashboard](https://zeabur.com/projects). Los headers y campos del body que vimos aquí son para contabilidad en tiempo real dentro de su código; el Dashboard es para inspección posterior.

--- a/docs/pages/ja-JP/ai-hub/_meta.ts
+++ b/docs/pages/ja-JP/ai-hub/_meta.ts
@@ -1,4 +1,5 @@
 export default {
   "n8n-integration": "n8n 統合",
-  "sillytavern-integration": "SillyTavern 統合"
+  "sillytavern-integration": "SillyTavern 統合",
+  "usage-and-cost": "使用量と料金の取得"
 }

--- a/docs/pages/ja-JP/ai-hub/usage-and-cost.mdx
+++ b/docs/pages/ja-JP/ai-hub/usage-and-cost.mdx
@@ -137,6 +137,32 @@ with httpx.stream(
 
 `stream_options.include_usage` を付けない場合、ストリーミングレスポンス全体に `usage` オブジェクトは一切現れません。
 
+## 特定の呼び出しを追跡する
+
+特定のリクエストを事後的に調査する場合——たとえば想定外の応答を診断する、料金を照合する、アプリケーション側のログと相関付けるなど——には、レスポンス body の `id`（completion ID）を使用してください：
+
+```python
+resp = client.chat.completions.create(...)
+print("request id:", resp.id)
+# chatcmpl-715764bf-675d-4d95-bbdc-80c037c8ce3f
+```
+
+<Callout type="warning">
+  必ず `response.id` を使用してください。`x-litellm-call-id` ヘッダーは**使用しないでください**。ヘッダーの値は LiteLLM がリクエストルーティング時に用いる内部トレース識別子であり、spend log には永続化されないため、その値による検索は結果を返しません。
+</Callout>
+
+[Zeabur Dashboard](https://zeabur.com/projects) の AI Hub ページで該当する日次ログを展開し、いずれかの行の情報アイコンをクリックすると、詳細ダイアログに Request ID とコピーボタンが表示されます。この値は `response.id` と完全に一致します。
+
+### キャッシュから返された応答には派生サフィックスが付与される
+
+LiteLLM がレスポンス全体を response cache から返した場合（Dashboard では「レスポンス全体がキャッシュから」のバッジが表示され、`cost = 0` となります）、記録される ID は元の ID に `_cache_hit<timestamp>` サフィックスを付加した形式となります：
+
+```
+chatcmpl-2ec370dd-83a6-41b4-817c-1646c57034bc_cache_hit1779350469.4126954
+```
+
+元のリクエストとキャッシュから返された応答は、spend log 上に独立した 2 件のエントリとして記録され、UUID プレフィックスを共有します。このプレフィックス単位で集約することにより、特定のプロンプトがキャッシュから配信された回数を集計できます。
+
 ## 過去の使用履歴
 
 日次の集計や 1 リクエスト単位の検索ログが必要な場合は、[Zeabur Dashboard](https://zeabur.com/projects) の AI Hub ページに月次サマリーと spend log の照会機能があります。本ページで紹介したヘッダーと body フィールドはアプリ内のリアルタイム計測向け、Dashboard は事後確認向けと使い分けてください。

--- a/docs/pages/ja-JP/ai-hub/usage-and-cost.mdx
+++ b/docs/pages/ja-JP/ai-hub/usage-and-cost.mdx
@@ -1,0 +1,147 @@
+---
+title: 使用量と料金の取得
+ogImageTitle: 使用量と料金の取得
+ogImageSubtitle: レスポンスヘッダーと usage オブジェクトからトークンと料金を取得
+---
+
+import { Callout } from 'nextra/components'
+
+# 使用量と料金の取得
+
+Zeabur AI Hub を呼び出すと、成功したリクエストには必ず 2 つの情報が付いてきます。今回のリクエストで消費したトークン数と、そのリクエストにかかった料金です。このページでは、それらをどこから読み取れるかを説明します。ダッシュボードへの組み込み、ユーザーごとの予算上限の設定、開発中の料金確認などに使えます。
+
+## 取得方法は 2 つ
+
+| 取得元 | 含まれる情報 | 向いている用途 |
+| --- | --- | --- |
+| レスポンスヘッダー | リクエスト単位の料金（USD）、キーの累計支出、Call ID | 最速。body をパースしなくてよい |
+| レスポンス body の `usage` オブジェクト | トークン数、プロンプトキャッシュの内訳、推論トークン | OpenAI SDK が標準で参照する場所 |
+
+成功レスポンスには両方とも常に含まれているので、どちらかを選ぶ必要はありません。コードの構造上読みやすい方を使ってください。
+
+## ヘッダーから読む
+
+レスポンスには `x-litellm-` で始まる一連のヘッダーが含まれます。
+
+| ヘッダー | 意味 |
+| --- | --- |
+| `x-litellm-response-cost` | このリクエストの料金（USD、float） |
+| `x-litellm-key-spend` | この API キーの累計支出（USD） |
+| `x-litellm-call-id` | リクエスト単位の識別子。問い合わせやトレースに使えます |
+| `x-litellm-model-id` | 内部のモデルデプロイ ID |
+| `x-litellm-model-group` | リクエストで指定したモデル名 |
+
+### curl
+
+```bash
+curl -i https://hnd1.aihub.zeabur.ai/v1/chat/completions \
+  -H "Authorization: Bearer YOUR_ZEABUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "claude-sonnet-4-5",
+    "messages": [{"role": "user", "content": "こんにちは"}],
+    "max_tokens": 32
+  }'
+```
+
+`-i` でレスポンスヘッダーも一緒に出力されます。`x-litellm-response-cost` の行が料金です。
+
+### Python
+
+OpenAI 公式 SDK は、レスポンスヘッダーをアプリケーション側に公開しません。ヘッダーから料金を取りたい場合は `httpx` で直接 HTTP を叩くのが手っ取り早いです。
+
+```python
+import httpx
+
+r = httpx.post(
+    "https://hnd1.aihub.zeabur.ai/v1/chat/completions",
+    headers={"Authorization": "Bearer YOUR_ZEABUR_API_KEY"},
+    json={
+        "model": "claude-sonnet-4-5",
+        "messages": [{"role": "user", "content": "こんにちは"}],
+        "max_tokens": 32,
+    },
+    timeout=60.0,
+)
+print("料金 (USD):", r.headers.get("x-litellm-response-cost"))
+print("usage:", r.json()["usage"])
+```
+
+## body の `usage` オブジェクトから読む
+
+レスポンス body の `usage` オブジェクトは OpenAI 互換です。Anthropic および OpenAI 系列モデルでは、必要に応じて追加フィールドが入ります。
+
+```json
+{
+  "usage": {
+    "prompt_tokens": 1024,
+    "completion_tokens": 256,
+    "total_tokens": 1280,
+    "prompt_tokens_details": {
+      "cached_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0
+    },
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0
+  }
+}
+```
+
+| フィールド | 対象モデル | 意味 |
+| --- | --- | --- |
+| `prompt_tokens` / `completion_tokens` / `total_tokens` | 全モデル | OpenAI の標準フィールド |
+| `prompt_tokens_details.cached_tokens` | OpenAI 系 | `prompt_tokens` のうちプロンプトキャッシュから配信された分（`prompt_tokens` に**含まれた**カウント） |
+| `cache_creation_input_tokens` | Anthropic 系 | このリクエストで Anthropic のプロンプトキャッシュに書き込まれたトークン数 |
+| `cache_read_input_tokens` | Anthropic 系 | このリクエストで Anthropic のプロンプトキャッシュから読み出されたトークン数 |
+| `completion_tokens_details.reasoning_tokens` | 推論モデル（`gpt-5`、`gpt-5-mini` など） | 内部推論で消費されたトークン |
+
+<Callout>
+  Anthropic と OpenAI ではキャッシュトークンの数え方が異なります。Anthropic の `cache_creation_input_tokens` と `cache_read_input_tokens` は `prompt_tokens` の**外側**に独立して報告されます。OpenAI の `cached_tokens` は `prompt_tokens` の**部分集合**です。body はプロバイダごとの形をそのまま返すので、呼び出したモデルに対応するフィールドを参照してください。
+</Callout>
+
+## ストリーミングレスポンス
+
+ストリーミングの場合、`usage` オブジェクトは明示的に有効化した場合のみ最終チャンクに含まれます。リクエストに `stream_options.include_usage: true` を指定してください。
+
+```python
+import httpx, json
+
+with httpx.stream(
+    "POST",
+    "https://hnd1.aihub.zeabur.ai/v1/chat/completions",
+    headers={"Authorization": "Bearer YOUR_ZEABUR_API_KEY"},
+    json={
+        "model": "claude-sonnet-4-5",
+        "messages": [{"role": "user", "content": "こんにちは"}],
+        "max_tokens": 32,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    },
+    timeout=60.0,
+) as r:
+    final_usage = None
+    for line in r.iter_lines():
+        if not line.startswith("data: "):
+            continue
+        payload = line[len("data: "):]
+        if payload == "[DONE]":
+            break
+        chunk = json.loads(payload)
+        if chunk.get("usage"):
+            final_usage = chunk["usage"]
+        # ... 既存のチャンク処理 ...
+    print("最終 usage:", final_usage)
+```
+
+`stream_options.include_usage` を付けない場合、ストリーミングレスポンス全体に `usage` オブジェクトは一切現れません。
+
+## 過去の使用履歴
+
+日次の集計や 1 リクエスト単位の検索ログが必要な場合は、[Zeabur Dashboard](https://zeabur.com/projects) の AI Hub ページに月次サマリーと spend log の照会機能があります。本ページで紹介したヘッダーと body フィールドはアプリ内のリアルタイム計測向け、Dashboard は事後確認向けと使い分けてください。
+
+## 関連リンク
+
+- [n8n で Zeabur AI Hub を使う](./n8n-integration)
+- [SillyTavern で Zeabur AI Hub を使う](./sillytavern-integration)

--- a/docs/pages/zh-CN/ai-hub/_meta.ts
+++ b/docs/pages/zh-CN/ai-hub/_meta.ts
@@ -1,4 +1,5 @@
 export default {
   "n8n-integration": "n8n 整合",
-  "sillytavern-integration": "SillyTavern 整合"
+  "sillytavern-integration": "SillyTavern 整合",
+  "usage-and-cost": "读取用量与费用"
 }

--- a/docs/pages/zh-CN/ai-hub/usage-and-cost.mdx
+++ b/docs/pages/zh-CN/ai-hub/usage-and-cost.mdx
@@ -137,6 +137,32 @@ with httpx.stream(
 
 如果不带 `stream_options.include_usage`，整个 streaming 响应里都不会出现 `usage` 对象。
 
+## 追踪特定一次调用
+
+如需于事后查询某次具体请求——例如诊断异常响应、核对费用，或与应用端日志关联——请使用 response body 中的 `id`（completion ID）：
+
+```python
+resp = client.chat.completions.create(...)
+print("request id:", resp.id)
+# chatcmpl-715764bf-675d-4d95-bbdc-80c037c8ce3f
+```
+
+<Callout type="warning">
+  请始终使用 `response.id`，**请勿**使用 `x-litellm-call-id` header。Header 中的值为 LiteLLM 内部路由使用的 trace 标识符，**不会写入 spend log**，以该值进行查询将不会返回任何结果。
+</Callout>
+
+在 [Zeabur Dashboard](https://zeabur.com/projects) 的 AI Hub 页面中展开相应的每日记录，点击任一行右侧的信息图标，详情对话框将显示 Request ID 并提供复制按钮；该值与 `response.id` 完全一致。
+
+### 命中缓存的响应携带派生后缀
+
+当 LiteLLM 直接从 response cache 返回完整响应时（Dashboard 中将显示「整条响应来自缓存」标签，且 `cost = 0`），所记录的 ID 为原始 ID 附加 `_cache_hit<timestamp>` 后缀：
+
+```
+chatcmpl-2ec370dd-83a6-41b4-817c-1646c57034bc_cache_hit1779350469.4126954
+```
+
+原始请求与缓存提供的响应在 spend log 中分别记录为两条独立条目，共用相同的 UUID 前缀。可基于该前缀进行聚合，以统计特定 prompt 被缓存提供的次数。
+
 ## 历史记录
 
 要查看每日累计或翻看每一笔请求的明细，请前往 [Zeabur Dashboard](https://zeabur.com/projects) 的 AI Hub 页面，它已经提供月度总览和单笔 spend log 查询。本页讲的 header 与 body 字段适合在代码里实时读取；事后翻账请直接用 Dashboard。

--- a/docs/pages/zh-CN/ai-hub/usage-and-cost.mdx
+++ b/docs/pages/zh-CN/ai-hub/usage-and-cost.mdx
@@ -1,0 +1,147 @@
+---
+title: 读取用量与费用
+ogImageTitle: 读取用量与费用
+ogImageSubtitle: 从响应 header 和 usage 对象获取 token 与费用
+---
+
+import { Callout } from 'nextra/components'
+
+# 读取用量与费用
+
+调用 Zeabur AI Hub 时，每一次成功的响应都会带回两项常用信息：这次请求用了多少 token、花了多少钱。本页说明它们放在哪里，方便您接到自己的看板、设定每位用户的预算上限，或在开发阶段顺手核对一下价格。
+
+## 两种获取方式
+
+| 来源 | 内容 | 适合的场景 |
+| --- | --- | --- |
+| 响应 header | 本次费用（USD）、密钥累计花费、Call ID | 最快，无需解析 body |
+| 响应 body 的 `usage` 对象 | Token 数、prompt 缓存细分、推理 token | OpenAI SDK 默认就读这里 |
+
+两者在每个成功响应里都会同时出现，不用二选一，按您代码里方便读的那个用就行。
+
+## 从 header 读
+
+每个响应都会带一组 `x-litellm-` 开头的 header：
+
+| Header | 含义 |
+| --- | --- |
+| `x-litellm-response-cost` | 本次请求的 USD 费用（浮点数） |
+| `x-litellm-key-spend` | 该 API 密钥到目前为止累计花费的 USD |
+| `x-litellm-call-id` | 本次请求的标识，反馈问题或链路追踪时用 |
+| `x-litellm-model-id` | 内部部署的模型 ID |
+| `x-litellm-model-group` | 您请求的公开模型名 |
+
+### curl
+
+```bash
+curl -i https://hnd1.aihub.zeabur.ai/v1/chat/completions \
+  -H "Authorization: Bearer YOUR_ZEABUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "claude-sonnet-4-5",
+    "messages": [{"role": "user", "content": "你好"}],
+    "max_tokens": 32
+  }'
+```
+
+`-i` 会把响应 header 一起打印出来，看 `x-litellm-response-cost` 那行就是费用。
+
+### Python
+
+OpenAI 官方 SDK 默认不会把响应 header 暴露给业务代码。如果要从 header 拿费用，直接用 `httpx` 走原生 HTTP：
+
+```python
+import httpx
+
+r = httpx.post(
+    "https://hnd1.aihub.zeabur.ai/v1/chat/completions",
+    headers={"Authorization": "Bearer YOUR_ZEABUR_API_KEY"},
+    json={
+        "model": "claude-sonnet-4-5",
+        "messages": [{"role": "user", "content": "你好"}],
+        "max_tokens": 32,
+    },
+    timeout=60.0,
+)
+print("费用 (USD):", r.headers.get("x-litellm-response-cost"))
+print("usage:", r.json()["usage"])
+```
+
+## 从 body 的 `usage` 对象读
+
+响应 body 里的 `usage` 对象遵循 OpenAI 格式。针对 Anthropic、OpenAI 系列模型，会额外带上相应字段：
+
+```json
+{
+  "usage": {
+    "prompt_tokens": 1024,
+    "completion_tokens": 256,
+    "total_tokens": 1280,
+    "prompt_tokens_details": {
+      "cached_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0
+    },
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0
+  }
+}
+```
+
+| 字段 | 适用模型 | 含义 |
+| --- | --- | --- |
+| `prompt_tokens` / `completion_tokens` / `total_tokens` | 全部 | OpenAI 标准字段 |
+| `prompt_tokens_details.cached_tokens` | OpenAI 系 | `prompt_tokens` 中来自 prompt 缓存的部分（已包含在 `prompt_tokens` 内） |
+| `cache_creation_input_tokens` | Anthropic 系 | 本次写入 Anthropic prompt 缓存的 token 数 |
+| `cache_read_input_tokens` | Anthropic 系 | 本次从 Anthropic prompt 缓存读出的 token 数 |
+| `completion_tokens_details.reasoning_tokens` | 推理模型（如 `gpt-5`、`gpt-5-mini`） | 内部推理消耗的 token |
+
+<Callout>
+  Anthropic 与 OpenAI 对"命中缓存的 token"算法不同：Anthropic 的 `cache_creation_input_tokens` 和 `cache_read_input_tokens` 在 `prompt_tokens` **之外**独立计；OpenAI 的 `cached_tokens` 是 `prompt_tokens` 的**子集**。body 会忠实地按各家原样返回，请按当前调用的模型选对应字段读。
+</Callout>
+
+## 流式（streaming）响应
+
+走 streaming 时，`usage` 对象只在您主动开启时才会出现在最后一个 chunk。请在请求里加上 `stream_options.include_usage: true`：
+
+```python
+import httpx, json
+
+with httpx.stream(
+    "POST",
+    "https://hnd1.aihub.zeabur.ai/v1/chat/completions",
+    headers={"Authorization": "Bearer YOUR_ZEABUR_API_KEY"},
+    json={
+        "model": "claude-sonnet-4-5",
+        "messages": [{"role": "user", "content": "你好"}],
+        "max_tokens": 32,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    },
+    timeout=60.0,
+) as r:
+    final_usage = None
+    for line in r.iter_lines():
+        if not line.startswith("data: "):
+            continue
+        payload = line[len("data: "):]
+        if payload == "[DONE]":
+            break
+        chunk = json.loads(payload)
+        if chunk.get("usage"):
+            final_usage = chunk["usage"]
+        # ...您原本的逐 chunk 处理...
+    print("最后一笔 usage:", final_usage)
+```
+
+如果不带 `stream_options.include_usage`，整个 streaming 响应里都不会出现 `usage` 对象。
+
+## 历史记录
+
+要查看每日累计或翻看每一笔请求的明细，请前往 [Zeabur Dashboard](https://zeabur.com/projects) 的 AI Hub 页面，它已经提供月度总览和单笔 spend log 查询。本页讲的 header 与 body 字段适合在代码里实时读取；事后翻账请直接用 Dashboard。
+
+## 相关链接
+
+- [在 n8n 中使用 Zeabur AI Hub](./n8n-integration)
+- [在 SillyTavern 中使用 Zeabur AI Hub](./sillytavern-integration)

--- a/docs/pages/zh-TW/ai-hub/_meta.ts
+++ b/docs/pages/zh-TW/ai-hub/_meta.ts
@@ -1,4 +1,5 @@
 export default {
   'n8n-integration': 'n8n 整合',
   'sillytavern-integration': 'SillyTavern 整合',
+  'usage-and-cost': '讀取用量與費用',
 }

--- a/docs/pages/zh-TW/ai-hub/usage-and-cost.mdx
+++ b/docs/pages/zh-TW/ai-hub/usage-and-cost.mdx
@@ -137,6 +137,32 @@ with httpx.stream(
 
 如果沒帶 `stream_options.include_usage`，整段 streaming 回應中都不會有 `usage` 物件。
 
+## 追蹤特定一次調用
+
+若需於事後查詢某次特定請求——例如診斷異常回應、核對費用，或與應用端日誌關聯——請使用 response body 中的 `id`（completion ID）：
+
+```python
+resp = client.chat.completions.create(...)
+print("request id:", resp.id)
+# chatcmpl-715764bf-675d-4d95-bbdc-80c037c8ce3f
+```
+
+<Callout type="warning">
+  請始終使用 `response.id`，**請勿**使用 `x-litellm-call-id` header。Header 中的值為 LiteLLM 內部路由所使用的 trace 識別碼，**不會寫入 spend log**，以該值進行查詢將不會回傳任何結果。
+</Callout>
+
+在 [Zeabur Dashboard](https://zeabur.com/projects) 的 AI Hub 頁面中展開對應的每日記錄，點擊任一資料列右側的資訊圖示，詳情對話框將顯示 Request ID 並提供複製按鈕；該值與 `response.id` 完全一致。
+
+### Cache 命中的回應帶有衍生後綴
+
+當 LiteLLM 直接以 response cache 中的內容回傳完整回應時（Dashboard 將顯示「整條回應來自快取」標籤，`cost = 0`），記錄中的 ID 為原始 ID 並附加 `_cache_hit<timestamp>` 後綴：
+
+```
+chatcmpl-2ec370dd-83a6-41b4-817c-1646c57034bc_cache_hit1779350469.4126954
+```
+
+原始請求與 cache 提供的回應在 spend log 中分別記錄為兩筆獨立資料，共用相同的 UUID 前綴。可依此前綴進行聚合，以統計特定 prompt 被快取提供的次數。
+
 ## 歷史紀錄
 
 如果是要看每日累計、或翻每一筆請求的明細，[Zeabur Dashboard](https://zeabur.com/projects) 的 AI Hub 頁面已經提供每月總覽與單筆 spend log 查詢。本頁列出的 header 與 body 欄位是給您在程式中即時讀取的；事後查詢請直接到 Dashboard。

--- a/docs/pages/zh-TW/ai-hub/usage-and-cost.mdx
+++ b/docs/pages/zh-TW/ai-hub/usage-and-cost.mdx
@@ -1,0 +1,147 @@
+---
+title: 讀取用量與費用
+ogImageTitle: 讀取用量與費用
+ogImageSubtitle: 從 response header 和 usage 物件取得 token 與費用
+---
+
+import { Callout } from 'nextra/components'
+
+# 讀取用量與費用
+
+呼叫 Zeabur AI Hub 時，每一個成功的回應都會帶上兩項您通常會關心的資料：這次請求用了多少 token、花了多少錢。這篇文件說明該往哪裡讀，方便您接到自己的儀表板、設定每個使用者的預算上限，或在開發階段隨手確認價格。
+
+## 兩種取得方式
+
+| 來源 | 內容 | 適合用在 |
+| --- | --- | --- |
+| Response header | 本次費用（USD）、金鑰累計花費、Call ID | 最快，不需要解析 body |
+| Response body 的 `usage` 物件 | Token 數、prompt 快取明細、推理 token | OpenAI SDK 原本就會讀的位置 |
+
+兩者每個成功回應都會同時出現，不用二選一，挑符合您程式碼結構的那個用即可。
+
+## 從 header 讀
+
+每個回應都會帶一組 `x-litellm-` 開頭的 header：
+
+| Header | 說明 |
+| --- | --- |
+| `x-litellm-response-cost` | 本次請求的 USD 費用（浮點數） |
+| `x-litellm-key-spend` | 該 API 金鑰目前累計花費的 USD |
+| `x-litellm-call-id` | 本次請求的識別碼，回報問題或追蹤時會用到 |
+| `x-litellm-model-id` | 內部部署的模型 ID |
+| `x-litellm-model-group` | 您送出的公開模型名稱 |
+
+### curl
+
+```bash
+curl -i https://hnd1.aihub.zeabur.ai/v1/chat/completions \
+  -H "Authorization: Bearer YOUR_ZEABUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "claude-sonnet-4-5",
+    "messages": [{"role": "user", "content": "你好"}],
+    "max_tokens": 32
+  }'
+```
+
+`-i` 會把 response header 一併印出來，看 `x-litellm-response-cost` 那一行就是費用。
+
+### Python
+
+OpenAI 官方 SDK 預設不會把 header 暴露給呼叫端。如果您要從 header 拿費用，直接用 `httpx` 跑原生 HTTP：
+
+```python
+import httpx
+
+r = httpx.post(
+    "https://hnd1.aihub.zeabur.ai/v1/chat/completions",
+    headers={"Authorization": "Bearer YOUR_ZEABUR_API_KEY"},
+    json={
+        "model": "claude-sonnet-4-5",
+        "messages": [{"role": "user", "content": "你好"}],
+        "max_tokens": 32,
+    },
+    timeout=60.0,
+)
+print("費用 (USD):", r.headers.get("x-litellm-response-cost"))
+print("usage:", r.json()["usage"])
+```
+
+## 從 body 的 `usage` 物件讀
+
+Response body 裡的 `usage` 物件相容於 OpenAI 的格式。針對 Anthropic、OpenAI 系列模型，會額外帶上對應的欄位：
+
+```json
+{
+  "usage": {
+    "prompt_tokens": 1024,
+    "completion_tokens": 256,
+    "total_tokens": 1280,
+    "prompt_tokens_details": {
+      "cached_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0
+    },
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0
+  }
+}
+```
+
+| 欄位 | 適用模型 | 說明 |
+| --- | --- | --- |
+| `prompt_tokens` / `completion_tokens` / `total_tokens` | 全部 | OpenAI 標準欄位 |
+| `prompt_tokens_details.cached_tokens` | OpenAI 系 | `prompt_tokens` 中由 prompt 快取提供的部分（已經算在 `prompt_tokens` 裡） |
+| `cache_creation_input_tokens` | Anthropic 系 | 本次寫入 Anthropic prompt 快取的 token 數 |
+| `cache_read_input_tokens` | Anthropic 系 | 本次從 Anthropic prompt 快取讀出的 token 數 |
+| `completion_tokens_details.reasoning_tokens` | 推理模型（如 `gpt-5`、`gpt-5-mini`） | 內部推理用掉的 token |
+
+<Callout>
+  Anthropic 與 OpenAI 對「命中快取的 token」算法不同：Anthropic 的 `cache_creation_input_tokens` 和 `cache_read_input_tokens` 是 `prompt_tokens` **以外**獨立計；OpenAI 的 `cached_tokens` 是 `prompt_tokens` 的**子集**。body 會誠實地按各家原樣回，您依照當下呼叫的模型對應的欄位讀即可。
+</Callout>
+
+## 串流（streaming）回應
+
+走 streaming 時，`usage` 物件只會在「您主動要求的情況下」出現在最後一個 chunk。請在請求中加上 `stream_options.include_usage: true`：
+
+```python
+import httpx, json
+
+with httpx.stream(
+    "POST",
+    "https://hnd1.aihub.zeabur.ai/v1/chat/completions",
+    headers={"Authorization": "Bearer YOUR_ZEABUR_API_KEY"},
+    json={
+        "model": "claude-sonnet-4-5",
+        "messages": [{"role": "user", "content": "你好"}],
+        "max_tokens": 32,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    },
+    timeout=60.0,
+) as r:
+    final_usage = None
+    for line in r.iter_lines():
+        if not line.startswith("data: "):
+            continue
+        payload = line[len("data: "):]
+        if payload == "[DONE]":
+            break
+        chunk = json.loads(payload)
+        if chunk.get("usage"):
+            final_usage = chunk["usage"]
+        # ...您原本逐 chunk 的處理...
+    print("最後一筆 usage:", final_usage)
+```
+
+如果沒帶 `stream_options.include_usage`，整段 streaming 回應中都不會有 `usage` 物件。
+
+## 歷史紀錄
+
+如果是要看每日累計、或翻每一筆請求的明細，[Zeabur Dashboard](https://zeabur.com/projects) 的 AI Hub 頁面已經提供每月總覽與單筆 spend log 查詢。本頁列出的 header 與 body 欄位是給您在程式中即時讀取的；事後查詢請直接到 Dashboard。
+
+## 相關連結
+
+- [在 n8n 中使用 Zeabur AI Hub](./n8n-integration)
+- [在 SillyTavern 中使用 Zeabur AI Hub](./sillytavern-integration)


### PR DESCRIPTION
New page under each locale's ai-hub/ subdir covering how to read token counts and cost from a request:

- Response headers (x-litellm-response-cost, x-litellm-key-spend, etc.)
- The body usage object, including Anthropic / OpenAI prompt-cache fields exposed by PLA-1598 and reasoning_tokens for gpt-5 series
- Streaming via stream_options.include_usage
- Pointer to the Dashboard for historical inspection

Each locale is hand-written for local register rather than translated verbatim — terminology, sentence structure, and examples adapt to en-US, zh-TW, zh-CN, ja-JP, and es-ES conventions.

Every claim is reproducible against the live hnd1 endpoint via the verification scripts in /Users/ca110us/Workspace/Zeabur/testai (test_response_cost.py, test_prompt_cache.py, test_reasoning_tokens.py).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/zeabur/pr/770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782033459&installation_id=128583772&pr_number=770&repository=zeabur%2Fzeabur&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fzeabur%2Fpull%2F770&signature=b1b47873fc1a4ad4f5d86533f8e9da84fea37650908faa9abe95395861bb172b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->