### PR TITLE
fix(middleware): avoid ERR_INVALID_URL crash in safeRedirect

### DIFF
--- a/docs/middleware.ts
+++ b/docs/middleware.ts
@@ -34,10 +34,14 @@ function findCanonicalLocale(segment: string): string | undefined {
 // Redirect using a relative path in the Location header to prevent the
 // internal service hostname (e.g. nextra-v2.zeabur.internal) from leaking
 // through the rewrite proxy — which causes Google "Redirect error".
-function safeRedirect(request: NextRequest, relativePath: string) {
-  const response = NextResponse.redirect(new URL(relativePath, request.url))
-  response.headers.set('Location', relativePath)
-  return response
+// Avoid `NextResponse.redirect(new URL(...))` because `request.url` can be a
+// relative path behind the rewrite proxy, which throws `ERR_INVALID_URL` and
+// returns a 500.
+function safeRedirect(_request: NextRequest, relativePath: string) {
+  return new NextResponse(null, {
+    status: 307,
+    headers: { Location: relativePath },
+  })
 }
 
 export function middleware(request: NextRequest) {


### PR DESCRIPTION
## Summary
- `safeRedirect` in `docs/middleware.ts` called `new URL(relativePath, request.url)`, which threw `ERR_INVALID_URL` when `request.url` arrived as a relative path through the landing rewrite proxy — returning 500 on `/:locale/docs` and spamming logs with ~7 errors/min.
- Build the redirect response directly with `new NextResponse(null, { status: 307, headers: { Location: relativePath } })` so the URL constructor is never invoked. The `Location` header was already being overridden with the relative path, so behavior is unchanged for the success path.

Fixes [PLA-1617](https://linear.app/zeabur/issue/PLA-1617).

## Test plan
- [ ] \`curl -o /dev/null -w \"%{http_code}\\n\" https://zeabur.com/zh-CN/docs\` returns a 3xx instead of 500 after deploy
- [ ] Docs container logs no longer show \`TypeError: Invalid URL\` from middleware

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/zeabur/pr/771"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782034069&installation_id=128583772&pr_number=771&repository=zeabur%2Fzeabur&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fzeabur%2Fpull%2F771&signature=96be46d9e2026c36f9cd168780ed84d27af5ac8a2921aaf1ee88995b0e111923"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->