### PR TITLE
fix(docs): redirect to absolute public URL in middleware (fix 500 on no-locale paths)

### DIFF
--- a/docs/middleware.ts
+++ b/docs/middleware.ts
@@ -31,17 +31,22 @@ function findCanonicalLocale(segment: string): string | undefined {
   return locales.find(l => l.toLowerCase() === segment.toLowerCase())
 }
 
-// Redirect using a relative path in the Location header to prevent the
-// internal service hostname (e.g. nextra-v2.zeabur.internal) from leaking
-// through the rewrite proxy — which causes Google "Redirect error".
-// Avoid `NextResponse.redirect(new URL(...))` because `request.url` can be a
-// relative path behind the rewrite proxy, which throws `ERR_INVALID_URL` and
-// returns a 500.
-function safeRedirect(_request: NextRequest, relativePath: string) {
-  return new NextResponse(null, {
-    status: 307,
-    headers: { Location: relativePath },
-  })
+// Build the redirect against the PUBLIC origin, not `request.url`.
+// zeabur.com rewrites /docs/* to http://nextra-v2.zeabur.internal:8080, so
+// `request.url`'s host is the internal upstream — using it leaks
+// `nextra-v2.zeabur.internal` and triggers Google "Redirect error".
+// A bare relative Location is also unusable: Next's middleware adapter
+// normalizes the Location header via `new URL(location)` with no base, which
+// throws `ERR_INVALID_URL` (500). So resolve the path against the public
+// forwarded host: the Location is absolute (adapter-safe) and points at the
+// user-facing domain.
+function safeRedirect(request: NextRequest, relativePath: string) {
+  const host =
+    request.headers.get('x-forwarded-host') ??
+    request.headers.get('host') ??
+    request.nextUrl.host
+  const proto = request.headers.get('x-forwarded-proto') ?? 'https'
+  return NextResponse.redirect(new URL(relativePath, `${proto}://${host}`))
 }
 
 export function middleware(request: NextRequest) {

--- a/docs/middleware.ts
+++ b/docs/middleware.ts
@@ -40,13 +40,29 @@ function findCanonicalLocale(segment: string): string | undefined {
 // throws `ERR_INVALID_URL` (500). So resolve the path against the public
 // forwarded host: the Location is absolute (adapter-safe) and points at the
 // user-facing domain.
+//
+// Behind multiple proxies `x-forwarded-*` can be comma-separated lists, so we
+// take the first token; a malformed origin would otherwise re-introduce the
+// `new URL` 500. As a last resort fall back to the (internal) request origin —
+// a working redirect beats a 500.
+function firstForwardedToken(value: string | null): string | undefined {
+  return value?.split(',')[0]?.trim() || undefined
+}
+
 function safeRedirect(request: NextRequest, relativePath: string) {
   const host =
-    request.headers.get('x-forwarded-host') ??
-    request.headers.get('host') ??
+    firstForwardedToken(request.headers.get('x-forwarded-host')) ??
+    firstForwardedToken(request.headers.get('host')) ??
     request.nextUrl.host
-  const proto = request.headers.get('x-forwarded-proto') ?? 'https'
-  return NextResponse.redirect(new URL(relativePath, `${proto}://${host}`))
+  const proto =
+    firstForwardedToken(request.headers.get('x-forwarded-proto'))?.toLowerCase() === 'http'
+      ? 'http'
+      : 'https'
+  try {
+    return NextResponse.redirect(new URL(relativePath, `${proto}://${host}`))
+  } catch {
+    return NextResponse.redirect(new URL(relativePath, request.nextUrl.origin))
+  }
 }
 
 export function middleware(request: NextRequest) {


### PR DESCRIPTION
## Problem
Every no-locale docs URL (e.g. `https://zeabur.com/docs/partner`, `/docs/install`, even `/docs`) returns **500** instead of 307-redirecting to the locale page. Locale-prefixed URLs (`/docs/en-US/partner`) are fine. This is the form external links / Google hit, and the runtime spams `ERR_INVALID_URL` (Google reports "Redirect error").

## Root cause
`safeRedirect` in `docs/middleware.ts` emitted a **bare relative `Location` header** (introduced in #771). Next.js's middleware adapter then normalizes the Location via `new URL(location)` **with no base**, and a relative value throws `TypeError: Invalid URL (ERR_INVALID_URL)` → 500.

This is the second half of a ping-pong:
- **pre-#771**: redirect built with `new URL(relativePath, request.url)` — but `zeabur.com` rewrites `/docs/*` to `http://nextra-v2.zeabur.internal:8080`, so `request.url`'s host is internal → leaked `nextra-v2.zeabur.internal` into the Location (Google "Redirect error").
- **#771**: switched to a relative Location to stop the leak → Next's adapter now throws on the relative value (this 500).

Verified the compiled middleware is identical across prod (`18e0e39e`), a clean local build, and a clean Docker build (same minified offsets `middleware.js:13:3418/3656/37494`) — so it was never a build-cache issue; the source genuinely 500s.

## Fix
Resolve the redirect against the **public forwarded host** (`x-forwarded-host`, falling back to `host`), producing an **absolute** Location. Absolute URLs are adapter-safe (no throw) and point at the user-facing domain (no internal-host leak) — fixing both failure modes at once.

## Verification
- **Local** (`next build` + `next start`, simulating proxy headers): `/docs/partner` → `307 https://zeabur.com/docs/en-US/partner`, `/docs/en-US/partner` stays `200`, no `ERR_INVALID_URL`.
- **Staging** (`docs-staging.zeabur.com`, deployed): `/docs/partner` → `307 https://docs-staging.zeabur.com/docs/en-US/partner`, `/docs/install`, `/docs/partner/sales-partner`, `/docs` all 307; locale paths 200; runtime clean.

## After merge
Verify on prod: `curl -I https://zeabur.com/docs/partner` → `307` → `…/docs/en-US/partner`, and runtime no longer logs `ERR_INVALID_URL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/zeabur/pr/777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782664481&installation_id=128583772&pr_number=777&repository=zeabur%2Fzeabur&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fzeabur%2Fpull%2F777&signature=cd5a251be5775e1d98fe3a27cf50f5169d2f266b8af4e4bbca3c8ead47aae560"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->