### PR TITLE
docs(server): document image architecture mismatch (ARM vs amd64) — "exec format error" (SEI-682)

### DIFF
--- a/docs/pages/en-US/server/_meta.ts
+++ b/docs/pages/en-US/server/_meta.ts
@@ -2,6 +2,7 @@ export default {
   purchase:         'Purchase a Server',
   register:         'Add a Server',
   operate:          'Manage Server',
+  'image-architecture': 'Image Architecture (ARM / amd64)',
   'shared-cluster': 'Shared Cluster (Deprecated)',
   firewall:         'Firewall & Security',
 }

--- a/docs/pages/en-US/server/image-architecture.mdx
+++ b/docs/pages/en-US/server/image-architecture.mdx
@@ -1,0 +1,73 @@
+---
+title: Image Architecture (ARM / amd64)
+ogImageTitle: Image Architecture (ARM / amd64)
+ogImageSubtitle: Fix "exec format error" caused by a CPU architecture mismatch
+---
+
+import { Callout } from 'nextra/components'
+
+# Image Architecture (ARM / amd64)
+
+If a service on your dedicated server exits immediately with an error like:
+
+```
+exec /usr/local/bin/docker-entrypoint.sh: exec format error
+```
+
+or the log says a file is "not a valid executable", the Docker image's CPU architecture does not match your server's CPU architecture. This page explains how to diagnose the mismatch and how to deploy images that run on your server.
+
+## What the error means
+
+`exec format error` means the operating system tried to run a binary compiled for a different CPU architecture. The error message names whatever file runs first — often `docker-entrypoint.sh` — so it can appear with any prebuilt image (PostgreSQL, Redis, your own application image, etc.). It is not specific to one service.
+
+Typical cases:
+
+- A `linux/amd64`-only image deployed on an ARM (`linux/arm64`) dedicated server. This is the most common case, because most prebuilt images and **all Zeabur-built images** target amd64.
+- A `linux/arm64` image — for example one built locally on an Apple Silicon Mac — deployed on an amd64 server. This usually fails with "no match for platform in manifest" instead; see the note in [Deploy a Custom Docker Image](/deploy/custom-docker-image).
+
+## Check your server's architecture
+
+SSH into the server and run:
+
+```bash
+uname -m
+```
+
+| Output | Architecture |
+| --- | --- |
+| `x86_64` | amd64 |
+| `aarch64` | arm64 (ARM) |
+
+## Check the image's architecture
+
+```bash
+docker manifest inspect <image>
+```
+
+If the manifest lists multiple platforms (a multi-arch image), the server pulls the matching one automatically and you are fine. If it lists only a single platform, that platform must match your server's architecture.
+
+## Zeabur builds are amd64-only
+
+<Callout type="warning">
+Zeabur's build system produces `linux/amd64` images only, and the build configuration has no option to choose a different target platform. A service deployed from Git therefore cannot run directly on an ARM dedicated server.
+</Callout>
+
+## Workaround: build for your server's architecture
+
+Build the image yourself for the server's architecture, push it to a registry, and deploy it as a prebuilt image:
+
+```bash
+docker buildx build --platform linux/arm64 -t <registry>/<image>:<tag> --push .
+```
+
+To produce one tag that runs on both architectures, build a multi-arch image:
+
+```bash
+docker buildx build --platform linux/amd64,linux/arm64 -t <registry>/<image>:<tag> --push .
+```
+
+Then deploy the pushed image following [Deploy a Custom Docker Image](/deploy/custom-docker-image).
+
+<Callout type="info">
+When choosing prebuilt images (including Marketplace-style ones) for an ARM server, prefer images that publish multi-arch manifests. You can verify with `docker manifest inspect` or on the image's registry page.
+</Callout>

--- a/docs/pages/es-ES/server/_meta.ts
+++ b/docs/pages/es-ES/server/_meta.ts
@@ -2,6 +2,7 @@ export default {
     "purchase": "Comprar Servidor",
     "register": "Registrar Servidor",
     "operate": "Mantener Servidor",
+    "image-architecture": "Arquitectura de Imagen (ARM / amd64)",
     "shared-cluster": "Clúster Compartido (Descontinuado)",
     "firewall": "Firewall y Seguridad",
 }

--- a/docs/pages/es-ES/server/image-architecture.mdx
+++ b/docs/pages/es-ES/server/image-architecture.mdx
@@ -1,0 +1,73 @@
+---
+title: Arquitectura de Imagen (ARM / amd64)
+ogImageTitle: Arquitectura de Imagen (ARM / amd64)
+ogImageSubtitle: Soluciona el "exec format error" causado por una arquitectura de CPU incompatible
+---
+
+import { Callout } from 'nextra/components'
+
+# Arquitectura de Imagen (ARM / amd64)
+
+Si un servicio en tu servidor dedicado se cierra inmediatamente con un error como:
+
+```
+exec /usr/local/bin/docker-entrypoint.sh: exec format error
+```
+
+o el log indica que un archivo "not a valid executable", la arquitectura de CPU de la imagen Docker no coincide con la arquitectura de CPU de tu servidor. Esta página explica cómo diagnosticar la incompatibilidad y cómo desplegar imágenes que funcionen en tu servidor.
+
+## Qué significa el error
+
+`exec format error` significa que el sistema operativo intentó ejecutar un binario compilado para otra arquitectura de CPU. El mensaje de error muestra el archivo que se ejecuta primero — normalmente `docker-entrypoint.sh` — por lo que puede aparecer con cualquier imagen preconstruida (PostgreSQL, Redis, tu propia imagen de aplicación, etc.). No es un problema específico de un servicio.
+
+Casos típicos:
+
+- Una imagen solo `linux/amd64` desplegada en un servidor dedicado ARM (`linux/arm64`). Es el caso más común, porque la mayoría de las imágenes preconstruidas y **todas las imágenes construidas por Zeabur** son para amd64.
+- Una imagen `linux/arm64` — por ejemplo construida localmente en un Mac con Apple Silicon — desplegada en un servidor amd64. Esto suele fallar con "no match for platform in manifest"; consulta la nota en [Desplegar una Imagen Docker Personalizada](/deploy/custom-docker-image).
+
+## Comprueba la arquitectura de tu servidor
+
+Conéctate al servidor por SSH y ejecuta:
+
+```bash
+uname -m
+```
+
+| Salida | Arquitectura |
+| --- | --- |
+| `x86_64` | amd64 |
+| `aarch64` | arm64 (ARM) |
+
+## Comprueba la arquitectura de la imagen
+
+```bash
+docker manifest inspect <image>
+```
+
+Si el manifest lista varias plataformas (imagen multiarquitectura), el servidor descarga automáticamente la versión correcta y no habrá problema. Si solo lista una plataforma, esa plataforma debe coincidir con la arquitectura de tu servidor.
+
+## Las construcciones de Zeabur son solo amd64
+
+<Callout type="warning">
+El sistema de construcción de Zeabur produce únicamente imágenes `linux/amd64`, y la configuración de build no tiene opción para elegir otra plataforma de destino. Por lo tanto, un servicio desplegado desde Git no puede ejecutarse directamente en un servidor dedicado ARM.
+</Callout>
+
+## Solución: construye para la arquitectura de tu servidor
+
+Construye la imagen tú mismo para la arquitectura del servidor, súbela a un registry y despliégala como imagen preconstruida:
+
+```bash
+docker buildx build --platform linux/arm64 -t <registry>/<image>:<tag> --push .
+```
+
+Para obtener un único tag que funcione en ambas arquitecturas, construye una imagen multiarquitectura:
+
+```bash
+docker buildx build --platform linux/amd64,linux/arm64 -t <registry>/<image>:<tag> --push .
+```
+
+Después, despliega la imagen siguiendo [Desplegar una Imagen Docker Personalizada](/deploy/custom-docker-image).
+
+<Callout type="info">
+Al elegir imágenes preconstruidas (incluidas las del Marketplace) para un servidor ARM, prefiere imágenes que publiquen manifests multiarquitectura. Puedes verificarlo con `docker manifest inspect` o en la página del registry de la imagen.
+</Callout>

--- a/docs/pages/ja-JP/server/_meta.ts
+++ b/docs/pages/ja-JP/server/_meta.ts
@@ -2,6 +2,7 @@ export default {
     "purchase":       "サーバーを購入する",
     "register":       "サーバーを登録する",
     "operate":        "サーバーを維護する",
+    'image-architecture': 'イメージアーキテクチャ（ARM / amd64）',
     'shared-cluster': '共有クラスター（廃止）',
     firewall:         'ファイアウォールとセキュリティ',
 }

--- a/docs/pages/ja-JP/server/image-architecture.mdx
+++ b/docs/pages/ja-JP/server/image-architecture.mdx
@@ -1,0 +1,73 @@
+---
+title: イメージアーキテクチャ（ARM / amd64）
+ogImageTitle: イメージアーキテクチャ（ARM / amd64）
+ogImageSubtitle: CPU アーキテクチャの不一致による「exec format error」の解決
+---
+
+import { Callout } from 'nextra/components'
+
+# イメージアーキテクチャ（ARM / amd64）
+
+専用サーバー上のサービスが起動直後に終了し、次のようなエラーが表示される場合：
+
+```
+exec /usr/local/bin/docker-entrypoint.sh: exec format error
+```
+
+またはログに「not a valid executable」と表示される場合、Docker イメージの CPU アーキテクチャがサーバーの CPU アーキテクチャと一致していません。このページでは、不一致の診断方法と、サーバーで動作するイメージのデプロイ方法を説明します。
+
+## エラーの意味
+
+`exec format error` は、OS が別の CPU アーキテクチャ向けにコンパイルされたバイナリを実行しようとしたことを意味します。エラーメッセージには最初に実行されるファイル（多くの場合 `docker-entrypoint.sh`）が表示されるため、あらゆるビルド済みイメージ（PostgreSQL、Redis、独自のアプリケーションイメージなど）で発生する可能性があり、特定のサービスに限った問題ではありません。
+
+典型的なケース：
+
+- ARM（`linux/arm64`）専用サーバーに `linux/amd64` のみのイメージをデプロイした場合。ほとんどのビルド済みイメージと **Zeabur がビルドするすべてのイメージ** は amd64 向けであるため、これが最も一般的なケースです。
+- amd64 サーバーに `linux/arm64` イメージ（たとえば Apple Silicon Mac でローカルビルドしたもの）をデプロイした場合。この場合は通常「no match for platform in manifest」エラーになります。詳細は[カスタム Docker イメージのデプロイ](/deploy/custom-docker-image)を参照してください。
+
+## サーバーのアーキテクチャを確認する
+
+サーバーに SSH 接続して実行します：
+
+```bash
+uname -m
+```
+
+| 出力 | アーキテクチャ |
+| --- | --- |
+| `x86_64` | amd64 |
+| `aarch64` | arm64（ARM） |
+
+## イメージのアーキテクチャを確認する
+
+```bash
+docker manifest inspect <image>
+```
+
+manifest に複数のプラットフォームが含まれている場合（マルチアーキテクチャイメージ）、サーバーは自動的に一致するものを取得するため問題ありません。単一のプラットフォームのみの場合は、そのプラットフォームがサーバーのアーキテクチャと一致している必要があります。
+
+## Zeabur のビルドは amd64 のみ
+
+<Callout type="warning">
+Zeabur のビルドシステムは `linux/amd64` イメージのみを生成し、ビルド設定で別のターゲットプラットフォームを指定するオプションはありません。そのため、Git からデプロイしたサービスは ARM 専用サーバーでは直接動作しません。
+</Callout>
+
+## 回避策：サーバーのアーキテクチャ向けに自分でビルドする
+
+サーバーのアーキテクチャ向けにイメージをビルドしてレジストリにプッシュし、ビルド済みイメージとしてデプロイします：
+
+```bash
+docker buildx build --platform linux/arm64 -t <registry>/<image>:<tag> --push .
+```
+
+1 つのタグで両方のアーキテクチャに対応させたい場合は、マルチアーキテクチャイメージをビルドします：
+
+```bash
+docker buildx build --platform linux/amd64,linux/arm64 -t <registry>/<image>:<tag> --push .
+```
+
+その後、[カスタム Docker イメージのデプロイ](/deploy/custom-docker-image)の手順に従って、プッシュしたイメージをデプロイします。
+
+<Callout type="info">
+ARM サーバーでビルド済みイメージ（マーケットプレイスのサービスを含む）を選ぶ際は、マルチアーキテクチャ manifest を公開しているイメージを優先してください。`docker manifest inspect` またはイメージのレジストリページで確認できます。
+</Callout>

--- a/docs/pages/zh-CN/server/_meta.ts
+++ b/docs/pages/zh-CN/server/_meta.ts
@@ -2,6 +2,7 @@ export default {
     "purchase":       "购买服务器",
     "register":       "注册服务器",
     "operate":        "维护服务器",
+    'image-architecture': '镜像架构（ARM / amd64）',
     'shared-cluster': '共享集群（已停止服务）',
     firewall:         '防火墙与安全设置',
 }

--- a/docs/pages/zh-CN/server/image-architecture.mdx
+++ b/docs/pages/zh-CN/server/image-architecture.mdx
@@ -1,0 +1,73 @@
+---
+title: 镜像架构（ARM / amd64）
+ogImageTitle: 镜像架构（ARM / amd64）
+ogImageSubtitle: 解决 CPU 架构不匹配导致的「exec format error」
+---
+
+import { Callout } from 'nextra/components'
+
+# 镜像架构（ARM / amd64）
+
+如果专属服务器上的服务一启动就退出，并出现类似以下错误：
+
+```
+exec /usr/local/bin/docker-entrypoint.sh: exec format error
+```
+
+或日志显示某个文件「not a valid executable」，说明 Docker 镜像的 CPU 架构与服务器的 CPU 架构不匹配。本页说明如何诊断架构不匹配，以及如何部署能在你的服务器上运行的镜像。
+
+## 错误的含义
+
+`exec format error` 表示操作系统尝试运行为另一种 CPU 架构编译的可执行文件。错误信息显示的是最先被执行的文件——通常是 `docker-entrypoint.sh`——因此任何预构建镜像（PostgreSQL、Redis、你自己的应用镜像等）都可能出现这个错误，并非特定服务的问题。
+
+常见情况：
+
+- 在 ARM（`linux/arm64`）专属服务器上部署了仅支持 `linux/amd64` 的镜像。这是最常见的情况，因为大多数预构建镜像与**所有 Zeabur 构建的镜像**都是 amd64 架构。
+- 在 amd64 服务器上部署了 `linux/arm64` 镜像——例如在 Apple Silicon Mac 上本地构建的镜像。这种情况通常会出现「no match for platform in manifest」错误，详见[部署 Docker 镜像](/deploy/custom-docker-image)中的说明。
+
+## 确认服务器的架构
+
+SSH 进入服务器后运行：
+
+```bash
+uname -m
+```
+
+| 输出 | 架构 |
+| --- | --- |
+| `x86_64` | amd64 |
+| `aarch64` | arm64（ARM） |
+
+## 确认镜像的架构
+
+```bash
+docker manifest inspect <image>
+```
+
+如果 manifest 列出多个平台（多架构镜像），服务器会自动拉取匹配的版本，不会有问题。如果只列出单一平台，该平台必须与服务器架构一致。
+
+## Zeabur 构建仅支持 amd64
+
+<Callout type="warning">
+Zeabur 的构建系统只会产出 `linux/amd64` 镜像，且构建配置没有指定其他目标平台的选项。因此从 Git 部署的服务无法直接在 ARM 专属服务器上运行。
+</Callout>
+
+## 解决方法：为服务器的架构自行构建
+
+自行为服务器的架构构建镜像，推送到 registry 后以预构建镜像方式部署：
+
+```bash
+docker buildx build --platform linux/arm64 -t <registry>/<image>:<tag> --push .
+```
+
+如果希望同一个 tag 在两种架构上都能运行，可构建多架构镜像：
+
+```bash
+docker buildx build --platform linux/amd64,linux/arm64 -t <registry>/<image>:<tag> --push .
+```
+
+然后按照[部署 Docker 镜像](/deploy/custom-docker-image)的步骤部署推送好的镜像。
+
+<Callout type="info">
+在 ARM 服务器上选用预构建镜像（包括模板市场的服务）时，建议优先选择提供多架构 manifest 的镜像。可以用 `docker manifest inspect` 或在镜像的 registry 页面上确认。
+</Callout>

--- a/docs/pages/zh-TW/server/_meta.ts
+++ b/docs/pages/zh-TW/server/_meta.ts
@@ -2,6 +2,7 @@ export default {
   purchase:         '購買主機',
   register:         '新增主機',
   operate:          '管理伺服器',
+  'image-architecture': '映像檔架構（ARM / amd64）',
   'shared-cluster': '共享叢集（已停止服務）',
   firewall:         '防火牆與安全設定',
 }

--- a/docs/pages/zh-TW/server/image-architecture.mdx
+++ b/docs/pages/zh-TW/server/image-architecture.mdx
@@ -1,0 +1,73 @@
+---
+title: 映像檔架構（ARM / amd64）
+ogImageTitle: 映像檔架構（ARM / amd64）
+ogImageSubtitle: 解決 CPU 架構不符造成的「exec format error」
+---
+
+import { Callout } from 'nextra/components'
+
+# 映像檔架構（ARM / amd64）
+
+如果專屬伺服器上的服務一啟動就退出，並出現類似以下錯誤：
+
+```
+exec /usr/local/bin/docker-entrypoint.sh: exec format error
+```
+
+或日誌顯示某個檔案「not a valid executable」，代表 Docker 映像檔的 CPU 架構與伺服器的 CPU 架構不符。本頁說明如何診斷架構不符，以及如何部署能在你的伺服器上執行的映像檔。
+
+## 錯誤的含義
+
+`exec format error` 表示作業系統嘗試執行為另一種 CPU 架構編譯的執行檔。錯誤訊息顯示的是最先被執行的檔案——通常是 `docker-entrypoint.sh`——因此任何預建映像檔（PostgreSQL、Redis、你自己的應用程式映像檔等）都可能出現這個錯誤，並非特定服務的問題。
+
+常見情境：
+
+- 在 ARM（`linux/arm64`）專屬伺服器上部署了僅支援 `linux/amd64` 的映像檔。這是最常見的情況，因為大多數預建映像檔與**所有 Zeabur 建置的映像檔**都是 amd64 架構。
+- 在 amd64 伺服器上部署了 `linux/arm64` 映像檔——例如在 Apple Silicon Mac 上本地建置的映像檔。這種情況通常會出現「no match for platform in manifest」錯誤，詳見[部署 Docker 映像檔](/deploy/custom-docker-image)中的說明。
+
+## 確認伺服器的架構
+
+SSH 進入伺服器後執行：
+
+```bash
+uname -m
+```
+
+| 輸出 | 架構 |
+| --- | --- |
+| `x86_64` | amd64 |
+| `aarch64` | arm64（ARM） |
+
+## 確認映像檔的架構
+
+```bash
+docker manifest inspect <image>
+```
+
+如果 manifest 列出多個平台（多架構映像檔），伺服器會自動拉取相符的版本，不會有問題。如果只列出單一平台，該平台必須與伺服器架構一致。
+
+## Zeabur 建置僅支援 amd64
+
+<Callout type="warning">
+Zeabur 的建置系統只會產出 `linux/amd64` 映像檔，且建置設定沒有指定其他目標平台的選項。因此從 Git 部署的服務無法直接在 ARM 專屬伺服器上執行。
+</Callout>
+
+## 解決方法：為伺服器的架構自行建置
+
+自行為伺服器的架構建置映像檔，推送到 registry 後以預建映像檔方式部署：
+
+```bash
+docker buildx build --platform linux/arm64 -t <registry>/<image>:<tag> --push .
+```
+
+如果希望同一個 tag 在兩種架構上都能執行，可建置多架構映像檔：
+
+```bash
+docker buildx build --platform linux/amd64,linux/arm64 -t <registry>/<image>:<tag> --push .
+```
+
+接著依照[部署 Docker 映像檔](/deploy/custom-docker-image)的步驟部署推送好的映像檔。
+
+<Callout type="info">
+在 ARM 伺服器上選用預建映像檔（包括模板市場的服務）時，建議優先選擇提供多架構 manifest 的映像檔。可以用 `docker manifest inspect` 或在映像檔的 registry 頁面上確認。
+</Callout>


### PR DESCRIPTION
## Summary

Closes doc gap [SEI-682](https://linear.app/zeabur/issue/SEI-682): the `exec format error` / "not a valid executable" symptom and its root cause (image CPU architecture ≠ server architecture) were only answered in forum replies, never in docs.

Adds a new page **`server/image-architecture`** in all 5 locales (en-US, zh-TW, zh-CN, ja-JP, es-ES):

- What `exec format error` means and why it appears with any prebuilt image (`docker-entrypoint.sh` is just the first file executed)
- How to check the server arch (`uname -m`) and the image arch (`docker manifest inspect`)
- Platform fact: **Zeabur's build system produces `linux/amd64` only** and there is no target-platform build option, so Git-deployed services can't run directly on ARM dedicated servers
- Workaround: `docker buildx build --platform linux/arm64 ... --push` and deploy as a prebuilt image; multi-arch build variant included
- Cross-links to `/deploy/custom-docker-image` (which already covers the inverse Apple-Silicon case)

## Verification

- `next build` passes; all 5 locale pages generated (`/{locale}/server/image-architecture`)
- Sidebar entry added after "Manage Server" in each locale's `_meta.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/zeabur/pr/782"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783700224&installation_id=128583772&pr_number=782&repository=zeabur%2Fzeabur&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fzeabur%2Fpull%2F782&signature=8bc64ba1ad82eafe8e0cec2f94534b0af843e50143c3b65286c8b767a0fa5bd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for diagnosing and resolving Docker image CPU architecture mismatches (ARM/amd64).
  * Includes troubleshooting steps to verify server and image architectures, common error scenarios, and solutions using Docker buildx for building multi-arch or architecture-specific images.
  * Documentation now available in English, Spanish, Japanese, Simplified Chinese, and Traditional Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->