### PR TITLE
docs(data): document pgvector usage and HNSW 2000-dim index limit (SEI-681)

### DIFF
--- a/docs/pages/en-US/operations/data/_meta.ts
+++ b/docs/pages/en-US/operations/data/_meta.ts
@@ -3,4 +3,5 @@ export default {
   'file-management': 'File Management',
   'backup-restore': 'Backup & Restore',
   'config-file-management': 'Config File Management',
+  pgvector: 'pgvector Vector Search',
 }

--- a/docs/pages/en-US/operations/data/pgvector.mdx
+++ b/docs/pages/en-US/operations/data/pgvector.mdx
@@ -1,0 +1,74 @@
+---
+title: pgvector Vector Search
+ogImageTitle: pgvector Vector Search
+ogImageSubtitle: Run pgvector on Zeabur and work around the HNSW dimension limit
+---
+
+import { Callout } from 'nextra/components'
+
+# pgvector Vector Search
+
+[pgvector](https://github.com/pgvector/pgvector) is the de-facto PostgreSQL extension for storing embeddings and running vector similarity search. This page covers how to get pgvector on Zeabur and the dimension limits you need to know before choosing an embedding model.
+
+## Getting pgvector on Zeabur
+
+The official `postgres` Docker image does not bundle pgvector — running `CREATE EXTENSION vector;` on it fails with:
+
+```
+ERROR: extension "vector" is not available
+```
+
+To use pgvector on Zeabur, deploy an image that ships the extension, for example [`pgvector/pgvector`](https://hub.docker.com/r/pgvector/pgvector) (tags follow the pattern `pg17`, `pg16`, …), as a [custom Docker image](/deploy/custom-docker-image). Then enable the extension once per database:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS vector;
+```
+
+## Dimension limits
+
+pgvector's limits differ between **storing** vectors and **indexing** them:
+
+| | Max dimensions |
+| --- | --- |
+| `vector` column (storage) | 16,000 |
+| HNSW / IVFFlat index on `vector` | **2,000** |
+| HNSW index on `halfvec` | 4,000 |
+
+This means you can store 3072-dimensional embeddings — such as OpenAI `text-embedding-3-large` or Gemini `gemini-embedding-001` — but creating an HNSW (or IVFFlat) index on them fails:
+
+```
+ERROR: column cannot have more than 2000 dimensions for hnsw index
+```
+
+## Workarounds for embeddings above 2,000 dimensions
+
+### Option 1: index as `halfvec` (recommended)
+
+pgvector 0.7+ supports half-precision vectors, and HNSW indexes on `halfvec` go up to 4,000 dimensions. You can keep the column as full-precision `vector(3072)` and build the index on a cast expression:
+
+```sql
+CREATE INDEX ON items
+USING hnsw ((embedding::halfvec(3072)) halfvec_cosine_ops);
+```
+
+Queries must use the same cast so the planner picks up the index:
+
+```sql
+SELECT * FROM items
+ORDER BY embedding::halfvec(3072) <=> $1::halfvec(3072)
+LIMIT 10;
+```
+
+The precision loss from half-precision is negligible for retrieval quality in practice.
+
+### Option 2: reduce the embedding dimensions
+
+Models trained with Matryoshka representation learning let you request fewer dimensions directly from the embedding API — for example OpenAI's `dimensions` parameter (`text-embedding-3-large` at 1,024 or 1,536) or Gemini's `output_dimensionality`. Embeddings at or below 2,000 dimensions can be HNSW-indexed without any cast.
+
+### Option 3: skip the index
+
+Without an index, pgvector falls back to an exact sequential scan — always correct, just slower. For small tables (up to tens of thousands of rows) this is often fast enough, and you can add an index later.
+
+<Callout type="info">
+IVFFlat has the same 2,000-dimension ceiling as HNSW for the `vector` type, so switching the index type alone does not help with high-dimensional embeddings.
+</Callout>

--- a/docs/pages/es-ES/operations/data/_meta.ts
+++ b/docs/pages/es-ES/operations/data/_meta.ts
@@ -3,4 +3,5 @@ export default {
   'file-management': 'Gestión de Archivos',
   'backup-restore': 'Respaldo y Restauración',
   'config-file-management': 'Gestión de Archivos de Configuración',
+  pgvector: 'Búsqueda Vectorial con pgvector',
 }

--- a/docs/pages/es-ES/operations/data/pgvector.mdx
+++ b/docs/pages/es-ES/operations/data/pgvector.mdx
@@ -1,0 +1,74 @@
+---
+title: Búsqueda Vectorial con pgvector
+ogImageTitle: Búsqueda Vectorial con pgvector
+ogImageSubtitle: Usa pgvector en Zeabur y evita el límite de dimensiones de HNSW
+---
+
+import { Callout } from 'nextra/components'
+
+# Búsqueda Vectorial con pgvector
+
+[pgvector](https://github.com/pgvector/pgvector) es la extensión de PostgreSQL de referencia para almacenar embeddings y ejecutar búsquedas por similitud vectorial. Esta página explica cómo usar pgvector en Zeabur y los límites de dimensiones que debes conocer antes de elegir un modelo de embeddings.
+
+## Usar pgvector en Zeabur
+
+La imagen Docker oficial `postgres` no incluye pgvector — ejecutar `CREATE EXTENSION vector;` falla con:
+
+```
+ERROR: extension "vector" is not available
+```
+
+Para usar pgvector en Zeabur, despliega una imagen que incluya la extensión, por ejemplo [`pgvector/pgvector`](https://hub.docker.com/r/pgvector/pgvector) (los tags siguen el patrón `pg17`, `pg16`, …), como [imagen Docker personalizada](/deploy/custom-docker-image). Después, habilita la extensión una vez por base de datos:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS vector;
+```
+
+## Límites de dimensiones
+
+Los límites de pgvector son distintos para **almacenar** vectores y para **indexarlos**:
+
+| | Dimensiones máximas |
+| --- | --- |
+| Columna `vector` (almacenamiento) | 16.000 |
+| Índice HNSW / IVFFlat sobre `vector` | **2.000** |
+| Índice HNSW sobre `halfvec` | 4.000 |
+
+Esto significa que puedes almacenar embeddings de 3072 dimensiones — como OpenAI `text-embedding-3-large` o Gemini `gemini-embedding-001` — pero crear un índice HNSW (o IVFFlat) sobre ellos falla:
+
+```
+ERROR: column cannot have more than 2000 dimensions for hnsw index
+```
+
+## Soluciones para embeddings de más de 2.000 dimensiones
+
+### Opción 1: indexar como `halfvec` (recomendado)
+
+pgvector 0.7+ soporta vectores de media precisión, y los índices HNSW sobre `halfvec` llegan hasta 4.000 dimensiones. Puedes mantener la columna como `vector(3072)` de precisión completa y crear el índice sobre una expresión de cast:
+
+```sql
+CREATE INDEX ON items
+USING hnsw ((embedding::halfvec(3072)) halfvec_cosine_ops);
+```
+
+Las consultas deben usar el mismo cast para que el planificador utilice el índice:
+
+```sql
+SELECT * FROM items
+ORDER BY embedding::halfvec(3072) <=> $1::halfvec(3072)
+LIMIT 10;
+```
+
+En la práctica, la pérdida de precisión de la media precisión es despreciable para la calidad de la recuperación.
+
+### Opción 2: reducir las dimensiones del embedding
+
+Los modelos entrenados con aprendizaje de representación Matryoshka permiten solicitar menos dimensiones directamente a la API de embeddings — por ejemplo el parámetro `dimensions` de OpenAI (`text-embedding-3-large` a 1.024 o 1.536) o `output_dimensionality` de Gemini. Los embeddings de 2.000 dimensiones o menos pueden indexarse con HNSW sin ningún cast.
+
+### Opción 3: prescindir del índice
+
+Sin índice, pgvector recurre a un escaneo secuencial exacto — siempre correcto, solo más lento. Para tablas pequeñas (hasta decenas de miles de filas) suele ser suficientemente rápido, y puedes añadir el índice más adelante.
+
+<Callout type="info">
+IVFFlat tiene el mismo techo de 2.000 dimensiones que HNSW para el tipo `vector`, por lo que cambiar solo el tipo de índice no resuelve el problema con embeddings de alta dimensionalidad.
+</Callout>

--- a/docs/pages/ja-JP/operations/data/_meta.ts
+++ b/docs/pages/ja-JP/operations/data/_meta.ts
@@ -3,4 +3,5 @@ export default {
   'file-management': 'ファイル管理',
   'backup-restore': 'バックアップと復元',
   'config-file-management': '設定ファイル管理',
+  pgvector: 'pgvector ベクトル検索',
 }

--- a/docs/pages/ja-JP/operations/data/pgvector.mdx
+++ b/docs/pages/ja-JP/operations/data/pgvector.mdx
@@ -1,0 +1,74 @@
+---
+title: pgvector ベクトル検索
+ogImageTitle: pgvector ベクトル検索
+ogImageSubtitle: Zeabur で pgvector を使い、HNSW の次元数制限を回避する
+---
+
+import { Callout } from 'nextra/components'
+
+# pgvector ベクトル検索
+
+[pgvector](https://github.com/pgvector/pgvector) は、PostgreSQL で埋め込み（embedding）を保存しベクトル類似度検索を実行するための定番拡張機能です。このページでは、Zeabur で pgvector を使う方法と、埋め込みモデルを選ぶ前に知っておくべき次元数の制限について説明します。
+
+## Zeabur で pgvector を使う
+
+公式の `postgres` Docker イメージには pgvector が含まれていないため、`CREATE EXTENSION vector;` を実行すると次のエラーで失敗します：
+
+```
+ERROR: extension "vector" is not available
+```
+
+Zeabur で pgvector を使うには、拡張機能を同梱したイメージ — たとえば [`pgvector/pgvector`](https://hub.docker.com/r/pgvector/pgvector)（タグは `pg17`、`pg16` などの形式）— を[カスタム Docker イメージ](/deploy/custom-docker-image)としてデプロイします。その後、データベースごとに一度だけ拡張機能を有効化します：
+
+```sql
+CREATE EXTENSION IF NOT EXISTS vector;
+```
+
+## 次元数の制限
+
+pgvector の制限は、ベクトルの**保存**と**インデックス作成**で異なります：
+
+| | 最大次元数 |
+| --- | --- |
+| `vector` カラム（保存） | 16,000 |
+| `vector` に対する HNSW / IVFFlat インデックス | **2,000** |
+| `halfvec` に対する HNSW インデックス | 4,000 |
+
+つまり、OpenAI `text-embedding-3-large` や Gemini `gemini-embedding-001` などの 3072 次元の埋め込みは保存できますが、HNSW（または IVFFlat）インデックスの作成は失敗します：
+
+```
+ERROR: column cannot have more than 2000 dimensions for hnsw index
+```
+
+## 2,000 次元を超える埋め込みへの対処法
+
+### 方法 1：`halfvec` でインデックスを作成する（推奨）
+
+pgvector 0.7 以降は半精度ベクトルをサポートしており、`halfvec` に対する HNSW インデックスは最大 4,000 次元まで対応します。カラムは全精度の `vector(3072)` のまま、インデックスだけキャスト式で作成できます：
+
+```sql
+CREATE INDEX ON items
+USING hnsw ((embedding::halfvec(3072)) halfvec_cosine_ops);
+```
+
+クエリでも同じキャストを使わないと、プランナがこのインデックスを使用しません：
+
+```sql
+SELECT * FROM items
+ORDER BY embedding::halfvec(3072) <=> $1::halfvec(3072)
+LIMIT 10;
+```
+
+半精度による精度低下が検索品質に与える影響は、実用上は無視できる程度です。
+
+### 方法 2：埋め込みの次元数を減らす
+
+Matryoshka 表現学習で訓練されたモデルでは、埋め込み API に直接少ない次元数を指定できます — たとえば OpenAI の `dimensions` パラメータ（`text-embedding-3-large` で 1,024 や 1,536 を指定）や Gemini の `output_dimensionality` です。2,000 次元以下の埋め込みは、キャストなしで HNSW インデックスを作成できます。
+
+### 方法 3：インデックスを作らない
+
+インデックスがない場合、pgvector は正確なシーケンシャルスキャンにフォールバックします — 結果は常に正確で、速度が遅くなるだけです。小規模なテーブル（数万行程度まで）であれば多くの場合これで十分で、必要になってからインデックスを追加できます。
+
+<Callout type="info">
+`vector` 型に対しては IVFFlat も HNSW と同じ 2,000 次元の上限があるため、インデックスの種類を変えるだけでは高次元埋め込みの問題は解決しません。
+</Callout>

--- a/docs/pages/zh-CN/operations/data/_meta.ts
+++ b/docs/pages/zh-CN/operations/data/_meta.ts
@@ -3,4 +3,5 @@ export default {
   'file-management': '文件管理',
   'backup-restore': '备份与还原',
   'config-file-management': '配置文件管理',
+  pgvector: 'pgvector 向量搜索',
 }

--- a/docs/pages/zh-CN/operations/data/pgvector.mdx
+++ b/docs/pages/zh-CN/operations/data/pgvector.mdx
@@ -1,0 +1,74 @@
+---
+title: pgvector 向量搜索
+ogImageTitle: pgvector 向量搜索
+ogImageSubtitle: 在 Zeabur 上使用 pgvector 并绕过 HNSW 维度限制
+---
+
+import { Callout } from 'nextra/components'
+
+# pgvector 向量搜索
+
+[pgvector](https://github.com/pgvector/pgvector) 是 PostgreSQL 上存储 embedding 与执行向量相似度搜索的主流扩展。本页说明如何在 Zeabur 上使用 pgvector，以及选择 embedding 模型前必须了解的维度限制。
+
+## 在 Zeabur 上使用 pgvector
+
+官方 `postgres` Docker 镜像并未内置 pgvector——直接运行 `CREATE EXTENSION vector;` 会失败：
+
+```
+ERROR: extension "vector" is not available
+```
+
+要在 Zeabur 上使用 pgvector，请部署内置该扩展的镜像，例如 [`pgvector/pgvector`](https://hub.docker.com/r/pgvector/pgvector)（tag 格式为 `pg17`、`pg16`……），部署方式参考[部署 Docker 镜像](/deploy/custom-docker-image)。然后在每个数据库启用一次扩展：
+
+```sql
+CREATE EXTENSION IF NOT EXISTS vector;
+```
+
+## 维度限制
+
+pgvector 对**存储**向量与**建立索引**的限制不同：
+
+| | 最大维度 |
+| --- | --- |
+| `vector` 列（存储） | 16,000 |
+| `vector` 上的 HNSW / IVFFlat 索引 | **2,000** |
+| `halfvec` 上的 HNSW 索引 | 4,000 |
+
+也就是说，你可以存储 3072 维的 embedding——例如 OpenAI `text-embedding-3-large` 或 Gemini `gemini-embedding-001`——但对它们创建 HNSW（或 IVFFlat）索引会失败：
+
+```
+ERROR: column cannot have more than 2000 dimensions for hnsw index
+```
+
+## 超过 2,000 维 embedding 的解决方法
+
+### 方法一：以 `halfvec` 建立索引（推荐）
+
+pgvector 0.7+ 支持半精度向量，`halfvec` 上的 HNSW 索引最高支持 4,000 维。列可以保持全精度的 `vector(3072)`，只在索引上使用类型转换：
+
+```sql
+CREATE INDEX ON items
+USING hnsw ((embedding::halfvec(3072)) halfvec_cosine_ops);
+```
+
+查询时必须使用相同的转换，查询规划器才会使用该索引：
+
+```sql
+SELECT * FROM items
+ORDER BY embedding::halfvec(3072) <=> $1::halfvec(3072)
+LIMIT 10;
+```
+
+实践中，半精度造成的精度损失对检索质量的影响可以忽略。
+
+### 方法二：降低 embedding 维度
+
+采用 Matryoshka 表示学习训练的模型，可以直接向 embedding API 请求更少的维度——例如 OpenAI 的 `dimensions` 参数（`text-embedding-3-large` 可指定 1,024 或 1,536 维）或 Gemini 的 `output_dimensionality`。2,000 维以下的 embedding 无需任何转换即可创建 HNSW 索引。
+
+### 方法三：不建立索引
+
+没有索引时，pgvector 会改用精确的顺序扫描——结果始终正确，只是较慢。对于小型数据表（数万行以内），这通常已经够快，之后需要时再加索引即可。
+
+<Callout type="info">
+对 `vector` 类型而言，IVFFlat 与 HNSW 有相同的 2,000 维上限，因此仅更换索引类型无法解决高维 embedding 的问题。
+</Callout>

--- a/docs/pages/zh-TW/operations/data/_meta.ts
+++ b/docs/pages/zh-TW/operations/data/_meta.ts
@@ -3,4 +3,5 @@ export default {
   'file-management': '檔案管理',
   'backup-restore': '備份與還原',
   'config-file-management': '設定檔管理',
+  pgvector: 'pgvector 向量搜尋',
 }

--- a/docs/pages/zh-TW/operations/data/pgvector.mdx
+++ b/docs/pages/zh-TW/operations/data/pgvector.mdx
@@ -1,0 +1,74 @@
+---
+title: pgvector 向量搜尋
+ogImageTitle: pgvector 向量搜尋
+ogImageSubtitle: 在 Zeabur 上使用 pgvector 並繞過 HNSW 維度限制
+---
+
+import { Callout } from 'nextra/components'
+
+# pgvector 向量搜尋
+
+[pgvector](https://github.com/pgvector/pgvector) 是 PostgreSQL 上儲存 embedding 與執行向量相似度搜尋的主流擴充套件。本頁說明如何在 Zeabur 上使用 pgvector，以及選擇 embedding 模型前必須知道的維度限制。
+
+## 在 Zeabur 上使用 pgvector
+
+官方 `postgres` Docker 映像檔並未內建 pgvector——直接執行 `CREATE EXTENSION vector;` 會失敗：
+
+```
+ERROR: extension "vector" is not available
+```
+
+要在 Zeabur 上使用 pgvector，請部署內建此擴充套件的映像檔，例如 [`pgvector/pgvector`](https://hub.docker.com/r/pgvector/pgvector)（tag 格式為 `pg17`、`pg16`⋯⋯），部署方式參考[部署 Docker 映像檔](/deploy/custom-docker-image)。接著在每個資料庫啟用一次擴充套件：
+
+```sql
+CREATE EXTENSION IF NOT EXISTS vector;
+```
+
+## 維度限制
+
+pgvector 對**儲存**向量與**建立索引**的限制不同：
+
+| | 最大維度 |
+| --- | --- |
+| `vector` 欄位（儲存） | 16,000 |
+| `vector` 上的 HNSW / IVFFlat 索引 | **2,000** |
+| `halfvec` 上的 HNSW 索引 | 4,000 |
+
+也就是說，你可以儲存 3072 維的 embedding——例如 OpenAI `text-embedding-3-large` 或 Gemini `gemini-embedding-001`——但對它們建立 HNSW（或 IVFFlat）索引會失敗：
+
+```
+ERROR: column cannot have more than 2000 dimensions for hnsw index
+```
+
+## 超過 2,000 維 embedding 的解決方法
+
+### 方法一：以 `halfvec` 建立索引（建議）
+
+pgvector 0.7+ 支援半精度向量，`halfvec` 上的 HNSW 索引最高支援 4,000 維。欄位可以維持全精度的 `vector(3072)`，只在索引上使用型別轉換：
+
+```sql
+CREATE INDEX ON items
+USING hnsw ((embedding::halfvec(3072)) halfvec_cosine_ops);
+```
+
+查詢時必須使用相同的轉換，查詢計畫器才會使用這個索引：
+
+```sql
+SELECT * FROM items
+ORDER BY embedding::halfvec(3072) <=> $1::halfvec(3072)
+LIMIT 10;
+```
+
+實務上，半精度造成的精度損失對檢索品質的影響可以忽略。
+
+### 方法二：降低 embedding 維度
+
+採用 Matryoshka 表示學習訓練的模型，可以直接向 embedding API 要求較少的維度——例如 OpenAI 的 `dimensions` 參數（`text-embedding-3-large` 可指定 1,024 或 1,536 維）或 Gemini 的 `output_dimensionality`。2,000 維以下的 embedding 不需要任何轉換即可建立 HNSW 索引。
+
+### 方法三：不建立索引
+
+沒有索引時，pgvector 會改用精確的循序掃描——結果永遠正確，只是比較慢。對於小型資料表（數萬筆以內），這通常已經夠快，之後需要時再加索引即可。
+
+<Callout type="info">
+對 `vector` 型別而言，IVFFlat 與 HNSW 有相同的 2,000 維上限，因此單純更換索引類型無法解決高維 embedding 的問題。
+</Callout>


### PR DESCRIPTION
## Summary

Closes doc gap [SEI-681](https://linear.app/zeabur/issue/SEI-681): pgvector's HNSW index caps at 2,000 dimensions, so 3072-dim embeddings (`text-embedding-3-large`, `gemini-embedding-001`) can't be HNSW-indexed directly — previously nothing in the docs warned about this or offered the workaround.

Adds a new page **`operations/data/pgvector`** in all 5 locales (en-US, zh-TW, zh-CN, ja-JP, es-ES):

- Getting pgvector on Zeabur: the official `postgres` image lacks the extension (`extension "vector" is not available`) — deploy `pgvector/pgvector` as a prebuilt image instead
- Dimension limits table: `vector` storage 16,000 / HNSW & IVFFlat on `vector` **2,000** / HNSW on `halfvec` 4,000
- Workarounds for >2,000-dim embeddings:
  1. `halfvec` index cast (recommended, pgvector ≥ 0.7) with matching query cast
  2. Reduce dimensions at the embedding API (Matryoshka / `dimensions` param)
  3. Skip the index (exact scan) for small tables

> Note: the Linear issue suggested `ivfflat` as a workaround, but IVFFlat has the **same 2,000-dim ceiling** as HNSW for the `vector` type — the page explicitly calls this out instead of propagating the incorrect suggestion.

## Verification

- `next build` passes; all 5 locale pages generated (`/{locale}/operations/data/pgvector`)
- Sidebar entry added to each locale's `operations/data/_meta.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/zeabur/pr/783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783700618&installation_id=128583772&pr_number=783&repository=zeabur%2Fzeabur&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fzeabur%2Fpull%2F783&signature=df05fb2566fe69d9bcf5cb4d9c6099fbd6e2025ae41abc9c6bd1e2c6973774eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive pgvector Vector Search documentation in five languages (English, Spanish, Japanese, Simplified Chinese, Traditional Chinese) with deployment guidance using custom PostgreSQL Docker images, dimension constraint specifications for storage and indexing, and three optimization strategies for high-dimensional embeddings including halfvec casting, dimensionality reduction, and sequential scan alternatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->