### PR TITLE
docs(template): WireGuard Easy admin password / PASSWORD_HASH guide (SEI-677)

### DIFF
--- a/docs/pages/en-US/template/_meta.ts
+++ b/docs/pages/en-US/template/_meta.ts
@@ -3,6 +3,7 @@ export default {
   'template-format':             'Template Format',
   'fork-git-repo-from-template': 'Fork Git Repo from Template',
   'maintain-template':           'Maintain & Update Templates',
+  'wireguard-easy':              'WireGuard Easy',
 
   // ── Hidden: old files (refactored) ────────────────────────────────────
   'template-in-code':            { display: 'hidden' },

--- a/docs/pages/en-US/template/wireguard-easy.mdx
+++ b/docs/pages/en-US/template/wireguard-easy.mdx
@@ -1,0 +1,57 @@
+---
+title: WireGuard Easy
+ogImageTitle: WireGuard Easy
+ogImageSubtitle: Configure the admin password for the WireGuard Easy template
+---
+
+import { Callout } from 'nextra/components'
+
+# WireGuard Easy
+
+[WireGuard Easy (wg-easy)](https://github.com/wg-easy/wg-easy) runs a WireGuard VPN server with a web-based management UI. You can deploy it on Zeabur from the [template marketplace](https://zeabur.com/templates). This page covers the admin-password configuration, which changed between wg-easy versions and is the most common source of deployment errors.
+
+## "You are using an invalid Configuration for wg-easy"
+
+If the service refuses to start and the runtime log shows:
+
+```
+You are using an invalid Configuration for wg-easy
+```
+
+your deployment is running **wg-easy v15 or later** with a `PASSWORD_HASH` environment variable set. wg-easy v15 removed `PASSWORD_HASH` (and most `WG_*` configuration variables) — any leftover legacy variable makes the service exit at startup.
+
+**Fix:**
+
+1. Open the service's **Variables** tab
+2. **Delete the `PASSWORD_HASH` variable**
+3. Restart the service
+4. Open the web UI — on first visit, a setup wizard asks you to create the admin username and password
+
+### Unattended setup (optional)
+
+To skip the setup wizard, set these variables **before the first start** instead:
+
+| Variable | Value |
+| --- | --- |
+| `INIT_ENABLED` | `true` |
+| `INIT_USERNAME` | admin username |
+| `INIT_PASSWORD` | admin password (plain text) |
+
+<Callout type="info">
+`INIT_*` variables are only read on the very first start, while the data volume is still empty. After setup completes they are ignored — remove them so the credentials don't linger in your service configuration.
+</Callout>
+
+## `PASSWORD_HASH` on wg-easy v14 and earlier
+
+Older wg-easy images (v14 and below) authenticate the web UI with a bcrypt hash in `PASSWORD_HASH`. Generate it with the bundled `wgpw` tool:
+
+```bash
+docker run --rm ghcr.io/wg-easy/wg-easy:14 wgpw 'YOUR_PASSWORD'
+# PASSWORD_HASH='$2a$12$...'
+```
+
+Paste the hash into the Zeabur variable **exactly as generated, with single `$` characters**.
+
+<Callout type="warning">
+Many wg-easy examples show the hash with doubled dollar signs (`$$2a$$12$$...`). That doubling is **docker-compose escaping only**. On Zeabur, paste the hash with single `$` — a value containing `$$` is not a valid bcrypt hash, and the web UI will reject every login.
+</Callout>

--- a/docs/pages/es-ES/template/_meta.ts
+++ b/docs/pages/es-ES/template/_meta.ts
@@ -3,5 +3,6 @@ export default {
   'template-format':             'Formato de Plantilla',
   'fork-git-repo-from-template': 'Fork Repositorio Git desde Plantilla',
   'maintain-template':           'Mantener y Actualizar Plantillas',
+  'wireguard-easy':              'WireGuard Easy',
   'template-in-code':            { display: 'hidden' },
 }

--- a/docs/pages/es-ES/template/wireguard-easy.mdx
+++ b/docs/pages/es-ES/template/wireguard-easy.mdx
@@ -1,0 +1,57 @@
+---
+title: WireGuard Easy
+ogImageTitle: WireGuard Easy
+ogImageSubtitle: Configura la contraseña de administrador de la plantilla WireGuard Easy
+---
+
+import { Callout } from 'nextra/components'
+
+# WireGuard Easy
+
+[WireGuard Easy (wg-easy)](https://github.com/wg-easy/wg-easy) ejecuta un servidor VPN WireGuard con una interfaz de gestión web, y puede desplegarse en Zeabur desde el [marketplace de plantillas](https://zeabur.com/templates). Esta página explica la configuración de la contraseña de administrador — que cambió entre versiones de wg-easy y es la fuente más común de errores de despliegue.
+
+## "You are using an invalid Configuration for wg-easy"
+
+Si el servicio no arranca y el log muestra:
+
+```
+You are using an invalid Configuration for wg-easy
+```
+
+tu despliegue ejecuta **wg-easy v15 o posterior** con la variable de entorno `PASSWORD_HASH` definida. wg-easy v15 eliminó `PASSWORD_HASH` (y la mayoría de las variables `WG_*`) — cualquier variable heredada hace que el servicio termine al arrancar.
+
+**Solución:**
+
+1. Abre la pestaña de **Variables** del servicio
+2. **Elimina la variable `PASSWORD_HASH`**
+3. Reinicia el servicio
+4. Abre la interfaz web — en la primera visita, un asistente de configuración te pedirá crear el usuario y la contraseña de administrador
+
+### Configuración desatendida (opcional)
+
+Para omitir el asistente, define estas variables **antes del primer arranque**:
+
+| Variable | Valor |
+| --- | --- |
+| `INIT_ENABLED` | `true` |
+| `INIT_USERNAME` | usuario administrador |
+| `INIT_PASSWORD` | contraseña de administrador (texto plano) |
+
+<Callout type="info">
+Las variables `INIT_*` solo se leen en el primer arranque, mientras el volumen de datos está vacío. Después de completar la configuración se ignoran — elimínalas para que las credenciales no queden en la configuración del servicio.
+</Callout>
+
+## `PASSWORD_HASH` en wg-easy v14 y anteriores
+
+Las imágenes antiguas de wg-easy (v14 y anteriores) autentican la interfaz web con un hash bcrypt en `PASSWORD_HASH`. Genéralo con la herramienta `wgpw` incluida:
+
+```bash
+docker run --rm ghcr.io/wg-easy/wg-easy:14 wgpw 'YOUR_PASSWORD'
+# PASSWORD_HASH='$2a$12$...'
+```
+
+Pega el hash en la variable de Zeabur **exactamente como se generó, con signos `$` simples**.
+
+<Callout type="warning">
+Muchos ejemplos de wg-easy muestran el hash con signos de dólar duplicados (`$$2a$$12$$...`). Ese duplicado es **solo para el escapado de docker-compose**. En Zeabur, pega el hash con `$` simples — un valor con `$$` no es un hash bcrypt válido y la interfaz web rechazará todos los inicios de sesión.
+</Callout>

--- a/docs/pages/ja-JP/template/_meta.ts
+++ b/docs/pages/ja-JP/template/_meta.ts
@@ -3,5 +3,6 @@ export default {
   'template-format':             'テンプレート形式',
   'fork-git-repo-from-template': 'テンプレートから Git リポジトリをフォーク',
   'maintain-template':           'テンプレートのメンテナンスと更新',
+  'wireguard-easy':              'WireGuard Easy',
   'template-in-code':            { display: 'hidden' },
 }

--- a/docs/pages/ja-JP/template/wireguard-easy.mdx
+++ b/docs/pages/ja-JP/template/wireguard-easy.mdx
@@ -1,0 +1,57 @@
+---
+title: WireGuard Easy
+ogImageTitle: WireGuard Easy
+ogImageSubtitle: WireGuard Easy テンプレートの管理者パスワード設定
+---
+
+import { Callout } from 'nextra/components'
+
+# WireGuard Easy
+
+[WireGuard Easy（wg-easy）](https://github.com/wg-easy/wg-easy)は、Web 管理画面付きの WireGuard VPN サーバーで、Zeabur の[テンプレートマーケットプレイス](https://zeabur.com/templates)からワンクリックでデプロイできます。このページでは管理者パスワードの設定方法を説明します — これは wg-easy のバージョン間で大きく変更されており、デプロイ時に最もよくあるエラーの原因です。
+
+## 「You are using an invalid Configuration for wg-easy」
+
+サービスが起動せず、ランタイムログに次のように表示される場合：
+
+```
+You are using an invalid Configuration for wg-easy
+```
+
+これは **wg-easy v15 以降** を実行しているのに、環境変数に `PASSWORD_HASH` が設定されていることを意味します。wg-easy v15 では `PASSWORD_HASH`（およびほとんどの `WG_*` 設定変数）が削除されており、レガシー変数が残っているとサービスは起動時に終了します。
+
+**解決方法：**
+
+1. サービスの「**環境変数**」タブを開く
+2. **`PASSWORD_HASH` 変数を削除する**
+3. サービスを再起動する
+4. Web UI を開く — 初回アクセス時にセットアップウィザードが管理者アカウントの作成を案内します
+
+### 無人セットアップ（オプション）
+
+セットアップウィザードをスキップしたい場合は、**初回起動前に**次の変数を設定します：
+
+| 変数 | 値 |
+| --- | --- |
+| `INIT_ENABLED` | `true` |
+| `INIT_USERNAME` | 管理者ユーザー名 |
+| `INIT_PASSWORD` | 管理者パスワード（平文） |
+
+<Callout type="info">
+`INIT_*` 変数は、データボリュームが空の「初回起動時」にのみ読み込まれます。セットアップ完了後は無視されるため、認証情報がサービス設定に残らないよう、後で削除することをお勧めします。
+</Callout>
+
+## wg-easy v14 以前の `PASSWORD_HASH`
+
+古い wg-easy イメージ（v14 以前）は、`PASSWORD_HASH` の bcrypt ハッシュで Web UI のログインを認証します。同梱の `wgpw` ツールで生成できます：
+
+```bash
+docker run --rm ghcr.io/wg-easy/wg-easy:14 wgpw 'YOUR_PASSWORD'
+# PASSWORD_HASH='$2a$12$...'
+```
+
+ハッシュ値は**生成されたまま（`$` は 1 つのまま）**Zeabur の環境変数に貼り付けてください。
+
+<Callout type="warning">
+wg-easy の例の多くは、ハッシュをドル記号 2 つの形式（`$$2a$$12$$...`）で示しています。これは **docker-compose 専用のエスケープ記法**です。Zeabur では `$` 1 つの形式で貼り付けてください — `$$` を含む値は有効な bcrypt ハッシュではなく、Web UI はすべてのログインを拒否します。
+</Callout>

--- a/docs/pages/zh-CN/template/_meta.ts
+++ b/docs/pages/zh-CN/template/_meta.ts
@@ -3,5 +3,6 @@ export default {
   'template-format':             '模板格式',
   'fork-git-repo-from-template': '从模板 Fork Git 仓库',
   'maintain-template':           '维护与更新模板',
+  'wireguard-easy':              'WireGuard Easy',
   'template-in-code':            { display: 'hidden' },
 }

--- a/docs/pages/zh-CN/template/wireguard-easy.mdx
+++ b/docs/pages/zh-CN/template/wireguard-easy.mdx
@@ -1,0 +1,57 @@
+---
+title: WireGuard Easy
+ogImageTitle: WireGuard Easy
+ogImageSubtitle: 配置 WireGuard Easy 模板的管理员密码
+---
+
+import { Callout } from 'nextra/components'
+
+# WireGuard Easy
+
+[WireGuard Easy（wg-easy）](https://github.com/wg-easy/wg-easy)是一套自带网页管理界面的 WireGuard VPN 服务器，可以从 Zeabur 的[模板市场](https://zeabur.com/templates)一键部署。本页说明管理员密码的配置方式——这在不同 wg-easy 版本之间有重大变动，也是部署时最常见的报错来源。
+
+## 「You are using an invalid Configuration for wg-easy」
+
+如果服务无法启动，且运行日志显示：
+
+```
+You are using an invalid Configuration for wg-easy
+```
+
+说明你的部署运行的是 **wg-easy v15 及以上版本**，但环境变量中设置了 `PASSWORD_HASH`。wg-easy v15 已移除 `PASSWORD_HASH`（以及大多数 `WG_*` 配置变量）——只要残留任何旧版变量，服务就会在启动时直接退出。
+
+**解决方式：**
+
+1. 打开服务的「**环境变量**」页签
+2. **删除 `PASSWORD_HASH` 这个变量**
+3. 重启服务
+4. 打开网页界面——首次访问时，设置向导会引导你创建管理员账号与密码
+
+### 免交互设置（可选）
+
+如果想跳过设置向导，可以在**首次启动前**改设以下变量：
+
+| 变量 | 值 |
+| --- | --- |
+| `INIT_ENABLED` | `true` |
+| `INIT_USERNAME` | 管理员账号 |
+| `INIT_PASSWORD` | 管理员密码（明文） |
+
+<Callout type="info">
+`INIT_*` 变量只在数据卷还是空的「第一次启动」时读取，设置完成后就会被忽略——建议事后删除这些变量，避免账号密码留在服务配置中。
+</Callout>
+
+## wg-easy v14 及更早版本的 `PASSWORD_HASH`
+
+较旧的 wg-easy 镜像（v14 以下）使用 `PASSWORD_HASH` 中的 bcrypt 哈希验证网页界面登录。可以用内置的 `wgpw` 工具生成：
+
+```bash
+docker run --rm ghcr.io/wg-easy/wg-easy:14 wgpw 'YOUR_PASSWORD'
+# PASSWORD_HASH='$2a$12$...'
+```
+
+将哈希值**原样（保持单个 `$` 字符）**粘贴进 Zeabur 的环境变量。
+
+<Callout type="warning">
+许多 wg-easy 示例会把哈希值写成双美元符格式（`$$2a$$12$$...`）。那是 **docker-compose 专用的转义写法**。在 Zeabur 上请粘贴单个 `$` 的版本——含有 `$$` 的值不是合法的 bcrypt 哈希，网页界面会拒绝所有登录。
+</Callout>

--- a/docs/pages/zh-TW/template/_meta.ts
+++ b/docs/pages/zh-TW/template/_meta.ts
@@ -3,6 +3,7 @@ export default {
   'template-format':             '模板格式說明',
   'fork-git-repo-from-template': '從模板 Fork Git 倉庫',
   'maintain-template':           '維護與更新模板',
+  'wireguard-easy':              'WireGuard Easy',
 
   // ── 隱藏：舊檔案（已重構）────────────────────────────────────────────
   'template-in-code':            { display: 'hidden' },

--- a/docs/pages/zh-TW/template/wireguard-easy.mdx
+++ b/docs/pages/zh-TW/template/wireguard-easy.mdx
@@ -1,0 +1,57 @@
+---
+title: WireGuard Easy
+ogImageTitle: WireGuard Easy
+ogImageSubtitle: 設定 WireGuard Easy 模板的管理員密碼
+---
+
+import { Callout } from 'nextra/components'
+
+# WireGuard Easy
+
+[WireGuard Easy（wg-easy）](https://github.com/wg-easy/wg-easy)是一套附帶網頁管理介面的 WireGuard VPN 伺服器，可以從 Zeabur 的[模板市場](https://zeabur.com/templates)一鍵部署。本頁說明管理員密碼的設定方式——這在不同 wg-easy 版本之間有重大變動，也是部署時最常見的錯誤來源。
+
+## 「You are using an invalid Configuration for wg-easy」
+
+如果服務無法啟動，且運行日誌顯示：
+
+```
+You are using an invalid Configuration for wg-easy
+```
+
+代表你的部署執行的是 **wg-easy v15 以上版本**，但環境變數中設定了 `PASSWORD_HASH`。wg-easy v15 已移除 `PASSWORD_HASH`（以及大多數 `WG_*` 設定變數）——只要殘留任何舊版變數，服務就會在啟動時直接退出。
+
+**解決方式：**
+
+1. 開啟服務的「**環境變數**」分頁
+2. **刪除 `PASSWORD_HASH` 這個變數**
+3. 重啟服務
+4. 開啟網頁介面——首次造訪時，設定精靈會引導你建立管理員帳號與密碼
+
+### 免互動設定（選用）
+
+如果想跳過設定精靈，可以在**首次啟動前**改設以下變數：
+
+| 變數 | 值 |
+| --- | --- |
+| `INIT_ENABLED` | `true` |
+| `INIT_USERNAME` | 管理員帳號 |
+| `INIT_PASSWORD` | 管理員密碼（明文） |
+
+<Callout type="info">
+`INIT_*` 變數只在資料 volume 還是空的「第一次啟動」時讀取，設定完成後就會被忽略——建議事後刪除這些變數，避免帳密留在服務設定中。
+</Callout>
+
+## wg-easy v14 及更早版本的 `PASSWORD_HASH`
+
+較舊的 wg-easy 映像檔（v14 以下）使用 `PASSWORD_HASH` 中的 bcrypt 雜湊驗證網頁介面登入。可以用內建的 `wgpw` 工具產生：
+
+```bash
+docker run --rm ghcr.io/wg-easy/wg-easy:14 wgpw 'YOUR_PASSWORD'
+# PASSWORD_HASH='$2a$12$...'
+```
+
+將雜湊值**原封不動（保持單一 `$` 字元）**貼進 Zeabur 的環境變數。
+
+<Callout type="warning">
+許多 wg-easy 範例會把雜湊值寫成雙錢號格式（`$$2a$$12$$...`）。那是 **docker-compose 專用的跳脫寫法**。在 Zeabur 上請貼單一 `$` 的版本——含有 `$$` 的值不是合法的 bcrypt 雜湊，網頁介面會拒絕所有登入。
+</Callout>


### PR DESCRIPTION
## Summary

Closes doc gap [SEI-677](https://linear.app/zeabur/issue/SEI-677): users deploying the WireGuard Easy template hit `invalid PASSWORD_HASH` / "You are using an invalid Configuration for wg-easy" with no documented guidance.

Adds a new page **`template/wireguard-easy`** in all 5 locales (en-US, zh-TW, zh-CN, ja-JP, es-ES):

- **wg-easy v15+** (what the current template `WNSZA0` actually deploys — `15.2.2`): `PASSWORD_HASH` was **removed** upstream; any leftover legacy variable makes the service exit with "invalid Configuration". Fix: delete the variable, restart, create the admin account via the first-run setup wizard — or unattended setup with `INIT_ENABLED`/`INIT_USERNAME`/`INIT_PASSWORD` (first start only)
- **wg-easy ≤ v14**: generate the bcrypt hash with `wgpw`, paste with **single `$`** — the `$$` doubling shown in wg-easy's own examples is docker-compose escaping and produces an invalid hash on Zeabur

Facts verified against [wg-easy upstream docs](https://wg-easy.github.io/wg-easy/latest/advanced/config/unattended-setup/) and the live template YAML, and consistent with the support resolution in forum ticket SUP-12726.

## Note for template maintainers

The marketplace template **WNSZA0** ships `ghcr.io/wg-easy/wg-easy:15.2.2` but still prompts users for a `PASSWORD_HASH` variable that v15 rejects — every fresh deploy from this template starts crashed. The template itself should be updated (drop the `PASSWORD_HASH` prompt, optionally wire `INIT_*`); this PR only fixes the docs side.

## Verification

- `next build` passes; all 5 locale pages generated (`/{locale}/template/wireguard-easy`)
- Sidebar entry added to each locale's `template/_meta.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/zeabur/pr/784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783701259&installation_id=128583772&pr_number=784&repository=zeabur%2Fzeabur&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fzeabur%2Fpull%2F784&signature=281a578dc1d2b38bdb4077c57b84bf419b717e5c75c677697704ec68433a3a29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added WireGuard Easy template documentation in English, Spanish, Japanese, Simplified Chinese, and Traditional Chinese.
  * Includes admin credential configuration, troubleshooting guidance, optional unattended setup options, and version-specific instructions.
  * Covers deployment best practices and platform-specific configuration notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->