### PR TITLE
docs(deploy): troubleshoot missing repos after GitHub App install (SEI-656)

### DIFF
--- a/docs/pages/en-US/deploy/methods/github-integration.mdx
+++ b/docs/pages/en-US/deploy/methods/github-integration.mdx
@@ -32,6 +32,32 @@ After completing the authorization, you will see a search box. Enter the name of
 
 ![Select Repository](/deploy/github/select-repo.webp)
 
+## Can't Find Your Repositories?
+
+If you installed the Zeabur GitHub App but some (or all) of your repositories don't show up in Zeabur's repository search, check the following two settings — they cover almost every case.
+
+### 1. Make sure your Zeabur account is linked to GitHub
+
+Installing the GitHub App and linking your GitHub account are **two different things**: the App grants Zeabur access to repositories, while the account link tells Zeabur *who you are* on GitHub. Zeabur uses your linked GitHub identity to determine which organizations (and therefore which installations) belong to you — without it, no repositories appear even if the App is installed.
+
+Go to [Console > Settings](https://dash.zeabur.com/account/general), scroll to the bottom, and confirm GitHub is linked. If not, link it and search again.
+
+### 2. Check the App's repository access in your organization
+
+When the Zeabur App is installed with "**Only select repositories**", repositories outside that list never show up. To change the access scope for an organization:
+
+1. On GitHub, go to your **organization's Settings** (for personal accounts: your own Settings)
+2. Open **Third-party Access → GitHub Apps** (on personal accounts: **Applications → Installed GitHub Apps**)
+3. Find **Zeabur** and click **Configure**
+4. Under **Repository access**, switch to "**All repositories**", or keep "Only select repositories" and add the missing repositories to the list
+5. Save — the repositories become searchable in Zeabur immediately
+
+<Callout type="info">
+Changing an organization's App configuration requires organization **Owner** permission. If you're a Member, ask an Owner to adjust the repository access, or request approval when GitHub prompts for it.
+</Callout>
+
+If both settings are correct and repositories from an organization you joined recently still don't appear, try re-saving the App configuration (step 4) to refresh the membership sync, or contact support via the [community forum](https://zeabur.com/forum).
+
 ## Removing GitHub Apps
 
 If you need to completely remove the Zeabur GitHub App, you can find "Zeabur" in GitHub's Settings > Integrations > Applications > Installed GitHub Apps, click "Configure", and then click "Uninstall" in the "Danger zone" of the popup page.

--- a/docs/pages/es-ES/deploy/methods/github-integration.mdx
+++ b/docs/pages/es-ES/deploy/methods/github-integration.mdx
@@ -32,6 +32,32 @@ Después de completar la autorización, verás un cuadro de búsqueda. Ingresa e
 
 ![Seleccionar Repositorio](/deploy/github/select-repo.webp)
 
+## ¿No encuentras tus repositorios?
+
+Si instalaste la GitHub App de Zeabur pero algunos (o todos) tus repositorios no aparecen en la búsqueda de repositorios de Zeabur, revisa estos dos ajustes — cubren casi todos los casos.
+
+### 1. Asegúrate de que tu cuenta de Zeabur está vinculada a GitHub
+
+Instalar la GitHub App y vincular tu cuenta de GitHub son **dos cosas distintas**: la App concede a Zeabur acceso a los repositorios, mientras que la vinculación le dice a Zeabur *quién eres* en GitHub. Zeabur usa tu identidad de GitHub vinculada para determinar a qué organizaciones (y por tanto a qué instalaciones) perteneces — sin ella, no aparece ningún repositorio aunque la App esté instalada.
+
+Ve a [Console > Settings](https://dash.zeabur.com/account/general), desplázate hasta el final y confirma que GitHub está vinculado. Si no lo está, vincúlalo y busca de nuevo.
+
+### 2. Revisa el acceso a repositorios de la App en tu organización
+
+Cuando la App de Zeabur se instala con "**Only select repositories**", los repositorios fuera de esa lista nunca aparecen. Para cambiar el alcance de acceso de una organización:
+
+1. En GitHub, ve a los **Settings de tu organización** (para cuentas personales: tus propios Settings)
+2. Abre **Third-party Access → GitHub Apps** (en cuentas personales: **Applications → Installed GitHub Apps**)
+3. Busca **Zeabur** y haz clic en **Configure**
+4. En **Repository access**, cambia a "**All repositories**", o mantén "Only select repositories" y añade los repositorios que falten a la lista
+5. Guarda — los repositorios pasan a ser buscables en Zeabur inmediatamente
+
+<Callout type="info">
+Cambiar la configuración de la App de una organización requiere permiso de **Owner** de la organización. Si eres Member, pide a un Owner que ajuste el acceso a repositorios, o envía la solicitud de aprobación cuando GitHub lo indique.
+</Callout>
+
+Si ambos ajustes son correctos y los repositorios de una organización a la que te uniste recientemente siguen sin aparecer, vuelve a guardar la configuración de la App (paso 4) para refrescar la sincronización de miembros, o contacta con soporte en el [foro de la comunidad](https://zeabur.com/forum).
+
 ## Eliminación de aplicaciones de GitHub
 
 Si necesitas eliminar completamente la aplicación GitHub de Zeabur, puedes encontrar "Zeabur" en Configuración > Integraciones > Aplicaciones > Aplicaciones GitHub instaladas de GitHub, hacer clic en "Configurar", y luego hacer clic en "Desinstalar" en la "Zona de peligro" de la página emergente.

--- a/docs/pages/ja-JP/deploy/methods/github-integration.mdx
+++ b/docs/pages/ja-JP/deploy/methods/github-integration.mdx
@@ -32,6 +32,32 @@ GitHub を使用したコードのデプロイにより、サービスに CI/CD 
 
 ![リポジトリの選択](/deploy/github/select-repo.webp)
 
+## リポジトリが見つからない場合
+
+Zeabur GitHub App をインストールしたのに、一部（またはすべて）のリポジトリが Zeabur のリポジトリ検索に表示されない場合は、次の 2 つの設定を確認してください — ほとんどのケースはこれでカバーされます。
+
+### 1. Zeabur アカウントが GitHub と連携されているか確認する
+
+GitHub App のインストールと GitHub アカウントの連携は**別のもの**です。App は Zeabur にリポジトリへのアクセス権を与え、アカウント連携は GitHub 上での*あなたが誰か*を Zeabur に伝えます。Zeabur は連携された GitHub ID から所属組織（およびどのインストールがあなたのものか）を判断するため、連携がないと App がインストール済みでもリポジトリは表示されません。
+
+[Console > Settings](https://dash.zeabur.com/account/general) を開いて一番下までスクロールし、GitHub が連携済みか確認してください。未連携の場合は連携してから再度検索してください。
+
+### 2. 組織における App のリポジトリアクセス範囲を確認する
+
+Zeabur App が「**Only select repositories**」でインストールされている場合、リスト外のリポジトリは表示されません。組織のアクセス範囲を変更するには：
+
+1. GitHub で**組織の Settings** を開く（個人アカウントの場合は自分の Settings）
+2. **Third-party Access → GitHub Apps** を開く（個人アカウントは **Applications → Installed GitHub Apps**）
+3. **Zeabur** を見つけて **Configure** をクリック
+4. **Repository access** で「**All repositories**」に切り替えるか、「Only select repositories」のまま不足しているリポジトリをリストに追加
+5. 保存すると、それらのリポジトリはすぐに Zeabur で検索可能になります
+
+<Callout type="info">
+組織の App 設定の変更には組織の **Owner** 権限が必要です。Member の場合は、Owner にリポジトリアクセスの調整を依頼するか、GitHub の承認リクエストを送信してください。
+</Callout>
+
+両方の設定が正しいのに、最近参加した組織のリポジトリがまだ表示されない場合は、App 設定をもう一度保存し直して（手順 4）メンバーシップ同期をリフレッシュするか、[コミュニティフォーラム](https://zeabur.com/forum)からサポートにお問い合わせください。
+
 ## GitHub Apps の削除
 
 Zeabur GitHub App を完全に削除する必要がある場合は、GitHub の Settings > Intergrations > Applications > Installed GitHub Apps で「Zeabur」を見つけ、「Configure」をクリックした後、ポップアップページの「Danger zone」で「Uninstall」をクリックします。

--- a/docs/pages/zh-CN/deploy/methods/github-integration.mdx
+++ b/docs/pages/zh-CN/deploy/methods/github-integration.mdx
@@ -32,6 +32,32 @@ Zeabur 提供了与 GitHub 集成的能力，这允许你将 GitHub 账号与 Ze
 
 ![选择仓库](/deploy/github/select-repo.webp)
 
+## 找不到你的仓库？
+
+如果你已安装 Zeabur GitHub App，但部分（或全部）仓库没有出现在 Zeabur 的仓库搜索中，请检查以下两项设置——几乎所有情况都涵盖在内。
+
+### 一、确认 Zeabur 账号已绑定 GitHub
+
+安装 GitHub App 和绑定 GitHub 账号是**两件不同的事**：App 让 Zeabur 有权限访问仓库，而账号绑定让 Zeabur 知道你在 GitHub 上*是谁*。Zeabur 通过你绑定的 GitHub 身份判断你属于哪些组织（以及哪些安装属于你）——没有绑定的话，即使 App 已安装也不会显示任何仓库。
+
+前往 [Console > Settings](https://dash.zeabur.com/account/general) 滑到最底部，确认已绑定 GitHub。如果尚未绑定，完成绑定后再搜索一次。
+
+### 二、检查组织内 App 的仓库访问范围
+
+如果 Zeabur App 安装时选择了「**Only select repositories**」，列表之外的仓库永远不会出现。要调整组织的访问范围：
+
+1. 在 GitHub 前往**组织的 Settings**（个人账号则是自己的 Settings）
+2. 打开 **Third-party Access → GitHub Apps**（个人账号为 **Applications → Installed GitHub Apps**）
+3. 找到 **Zeabur**，点击 **Configure**
+4. 在 **Repository access** 中改选「**All repositories**」，或保持「Only select repositories」并把缺少的仓库加入列表
+5. 保存后，这些仓库立即可以在 Zeabur 中搜索到
+
+<Callout type="info">
+修改组织的 App 设置需要组织 **Owner** 权限。如果你是 Member，请组织 Owner 协助调整仓库访问范围，或在 GitHub 弹出提示时提交审批请求。
+</Callout>
+
+如果以上两项设置都正确，但最近加入的组织仓库仍未出现，可以重新保存一次 App 设置（步骤 4）以刷新成员同步，或通过[社区论坛](https://zeabur.com/forum)联系支持团队。
+
 ## 移除 GitHub Apps
 
 如果需要完全移除 Zeabur GitHub App，可以在 GitHub 的 Settings > Intergrations > Applications > Installed GitHub Apps 中找到“Zeabur”，点击“Configure”后在弹出页面中的“Danger zone”点击“Uninstall”即可

--- a/docs/pages/zh-TW/deploy/methods/github-integration.mdx
+++ b/docs/pages/zh-TW/deploy/methods/github-integration.mdx
@@ -32,6 +32,32 @@ Zeabur 提供了與 GitHub 整合的能力，這允許你將 GitHub 帳號與 Ze
 
 ![選擇儲存庫](/deploy/github/select-repo.webp)
 
+## 找不到你的儲存庫？
+
+如果你已安裝 Zeabur GitHub App，但部分（或全部）儲存庫沒有出現在 Zeabur 的儲存庫搜尋中，請檢查以下兩項設定——幾乎所有情況都涵蓋在內。
+
+### 一、確認 Zeabur 帳號已綁定 GitHub
+
+安裝 GitHub App 和綁定 GitHub 帳號是**兩件不同的事**：App 讓 Zeabur 有權限存取儲存庫，而帳號綁定讓 Zeabur 知道你在 GitHub 上*是誰*。Zeabur 透過你綁定的 GitHub 身分判斷你屬於哪些組織（以及哪些安裝屬於你）——沒有綁定的話，即使 App 已安裝也不會顯示任何儲存庫。
+
+前往 [Console > Settings](https://dash.zeabur.com/account/general) 滑到最底下，確認已綁定 GitHub。如果尚未綁定，完成綁定後再搜尋一次。
+
+### 二、檢查組織內 App 的儲存庫存取範圍
+
+如果 Zeabur App 安裝時選擇了「**Only select repositories**」，清單之外的儲存庫永遠不會出現。要調整組織的存取範圍：
+
+1. 在 GitHub 前往**組織的 Settings**（個人帳號則是自己的 Settings）
+2. 開啟 **Third-party Access → GitHub Apps**（個人帳號為 **Applications → Installed GitHub Apps**）
+3. 找到 **Zeabur**，點選 **Configure**
+4. 在 **Repository access** 中改選「**All repositories**」，或維持「Only select repositories」並把缺少的儲存庫加入清單
+5. 儲存後，這些儲存庫立即可以在 Zeabur 中搜尋到
+
+<Callout type="info">
+修改組織的 App 設定需要組織 **Owner** 權限。如果你是 Member，請組織 Owner 協助調整儲存庫存取範圍，或在 GitHub 跳出提示時送出核准請求。
+</Callout>
+
+如果以上兩項設定都正確，但最近加入的組織儲存庫仍未出現，可以重新儲存一次 App 設定（步驟 4）以刷新成員同步，或透過[社群論壇](https://zeabur.com/forum)聯絡支援團隊。
+
 ## 移除 GitHub Apps
 
 如果需要完全移除 Zeabur GitHub App，可以在 GitHub 的 Settings > Intergrations > Applications > Installed GitHub Apps 中找到「Zeabur」，點選「Configure」後在彈出頁面中的「Danger zone」點選「Uninstall」即可


### PR DESCRIPTION
## Summary

Closes doc gap [SEI-656](https://linear.app/zeabur/issue/SEI-656): users who installed the Zeabur GitHub App frequently can't find their organization repos in Zeabur, and the docs offered no guidance.

Adds a **"Can't Find Your Repositories?"** section to `deploy/methods/github-integration` in all 5 locales, covering the two verified root causes:

1. **Zeabur account not linked to GitHub** — App install and account linking are different things; Zeabur resolves which orgs/installations belong to you from the linked GitHub identity (per internal SOP `MAN-sop-github-app`: `githubID: null` → no repos, regardless of App state)
2. **App installed with "Only select repositories"** — step-by-step path to GitHub → org Settings → Third-party Access → GitHub Apps → Zeabur → Configure → Repository access, plus the Owner-permission caveat for Members

Also includes the edge case of recently-joined org members (membership sync) with re-save + forum fallback.

Only the canonical `deploy/methods/` pages were touched — the legacy hidden `deploy/github-integration.mdx` (en-US, zh-TW) was left alone to avoid recreating the dual-source RAG problem.

## Verification

- `next build` passes; all 5 locale pages regenerate cleanly
- Section placed before "Removing GitHub Apps" in each locale

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/zeabur/pr/785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783701575&installation_id=128583772&pr_number=785&repository=zeabur%2Fzeabur&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fzeabur%2Fpull%2F785&signature=0d181a0fb5a3de1b6251908b4d59b74b5be5d0e6e475d64f0f96bd8f609f4881"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guidance for missing repositories after installing the GitHub App
  * Includes verification steps for account linkage and repository access scope configuration
  * Provides instructions for adjusting permissions and contacting support if issues persist
  * Updated across all supported language versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->