### PR TITLE
feat(docs): ShareButton in article main slot (MKT-2511)

### DIFF
--- a/docs/components/FeedbackWidget/useZeaburAuth.ts
+++ b/docs/components/FeedbackWidget/useZeaburAuth.ts
@@ -5,6 +5,7 @@ export interface ZeaburUser {
   name: string
   username: string
   avatarURL: string
+  referralCode?: string | null
 }
 
 interface AuthState {
@@ -37,7 +38,7 @@ export function useZeaburAuth(): AuthState {
       credentials: 'include',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        query: '{ me { _id name username avatarURL } }',
+        query: '{ me { _id name username avatarURL referralCode } }',
       }),
     })
       .then((res) => res.json())

--- a/docs/components/ScrollToTopButton.tsx
+++ b/docs/components/ScrollToTopButton.tsx
@@ -1,0 +1,38 @@
+// Icon-only scroll-to-top button used in the TOC sidebar next to ShareButton.
+// Replaces Nextra's built-in toc.backToTop (which renders "Scroll to top" + chevron)
+// so we can sit it inline with ShareButton on the same row.
+
+export default function ScrollToTopButton() {
+  return (
+    <button
+      type="button"
+      className="share-button"
+      onClick={() =>
+        typeof window !== 'undefined' &&
+        window.scrollTo({ top: 0, behavior: 'smooth' })
+      }
+      aria-label="Scroll to top"
+      title="Scroll to top"
+    >
+      <ChevronUpIcon />
+    </button>
+  )
+}
+
+function ChevronUpIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <polyline points="18 15 12 9 6 15" />
+    </svg>
+  )
+}

--- a/docs/components/ScrollToTopButton.tsx
+++ b/docs/components/ScrollToTopButton.tsx
@@ -30,7 +30,7 @@ function ChevronUpIcon() {
       strokeWidth="2"
       strokeLinecap="round"
       strokeLinejoin="round"
-      aria-hidden
+      aria-hidden="true"
     >
       <polyline points="18 15 12 9 6 15" />
     </svg>

--- a/docs/components/ShareButton/index.tsx
+++ b/docs/components/ShareButton/index.tsx
@@ -106,7 +106,9 @@ export default function ShareButton({
 
   const handleShare = async () => {
     const pagePath = (router.asPath || '/').split(/[?#]/)[0]
-    const shareUrl = `https://zeabur.com${pagePath}?referralCode=${user.referralCode}`
+    const shareUrlObj = new URL(`https://zeabur.com${pagePath}`)
+    shareUrlObj.searchParams.set('referralCode', user.referralCode!)
+    const shareUrl = shareUrlObj.toString()
     const text = tmpl
       .replace('{{url}}', shareUrl)
       .replace('{{code}}', user.referralCode!)
@@ -153,7 +155,8 @@ export default function ShareButton({
       type="button"
       className={`share-button ${visibilityClass} ${copied ? 'share-button-copied' : ''}`}
       onClick={handleShare}
-      aria-label={shareLabel}
+      aria-label={copied ? copiedLabel : shareLabel}
+      aria-live="polite"
     >
       {copied ? (
         <>
@@ -181,7 +184,7 @@ function ShareIcon() {
       strokeWidth="2"
       strokeLinecap="round"
       strokeLinejoin="round"
-      aria-hidden
+      aria-hidden="true"
     >
       <circle cx="18" cy="5" r="3" />
       <circle cx="6" cy="12" r="3" />
@@ -199,7 +202,7 @@ function CheckIcon() {
       height="14"
       viewBox="0 0 20 20"
       fill="none"
-      aria-hidden
+      aria-hidden="true"
     >
       <path
         d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.7-10.3a.75.75 0 00-1.06-1.06L9 10.29 7.36 8.64a.75.75 0 00-1.06 1.06l2.25 2.25a.75.75 0 001.06 0l4.09-4.25z"

--- a/docs/components/ShareButton/index.tsx
+++ b/docs/components/ShareButton/index.tsx
@@ -11,6 +11,44 @@ import { useZeaburAuth } from '../FeedbackWidget/useZeaburAuth'
 
 const DEFAULT_DISCOUNT = 5
 
+// PostHog public token (same project as zeabur.com — see pages/_app.tsx there).
+// Docs doesn't ship the posthog-js SDK, so we POST directly to the capture API.
+const POSTHOG_KEY = 'phc_TcgrjtKUGtTltFwWGj2Xhmuyv5ZHtrufIE8wgkLsruD'
+const POSTHOG_HOST = 'https://us.i.posthog.com'
+
+function captureShareButtonClicked(props: {
+  user_id: string
+  username?: string
+  page_path: string
+  locale: string
+  share_method: 'native_share' | 'clipboard'
+}) {
+  if (typeof window === 'undefined') return
+  fetch(`${POSTHOG_HOST}/capture/`, {
+    method: 'POST',
+    keepalive: true,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      api_key: POSTHOG_KEY,
+      event: 'share_button_clicked',
+      distinct_id: props.user_id,
+      properties: {
+        user_id: props.user_id,
+        username: props.username,
+        is_logged_in: true,
+        surface: 'docs',
+        page_path: props.page_path,
+        locale: props.locale,
+        share_method: props.share_method,
+        has_referral_code: true,
+        timestamp: Date.now(),
+      },
+    }),
+  }).catch(() => {
+    // best-effort; swallow network errors so share UX still works
+  })
+}
+
 const SHARE_MESSAGES: Record<string, string> = {
   'en-US':
     'Purchase servers or AI Hub credits at {{url}} — enter my referral code "{{code}}" at checkout to enjoy {{discount}}% off!',
@@ -59,6 +97,18 @@ export default function ShareButton() {
       .replace('{{url}}', shareUrl)
       .replace('{{code}}', user.referralCode!)
       .replace('{{discount}}', String(DEFAULT_DISCOUNT))
+
+    const willUseNativeShare =
+      typeof navigator !== 'undefined' &&
+      typeof navigator.share === 'function'
+
+    captureShareButtonClicked({
+      user_id: user._id,
+      username: user.username,
+      page_path: pagePath,
+      locale,
+      share_method: willUseNativeShare ? 'native_share' : 'clipboard',
+    })
 
     if (
       typeof navigator !== 'undefined' &&

--- a/docs/components/ShareButton/index.tsx
+++ b/docs/components/ShareButton/index.tsx
@@ -81,7 +81,18 @@ const COPIED_LABEL: Record<string, string> = {
   'es-ES': 'Copiado',
 }
 
-export default function ShareButton() {
+/**
+ * variant:
+ *   - "toc": compact, rendered in the TOC sidebar (desktop only, hidden below xl)
+ *   - "inline": rendered below main content (mobile only, hidden at xl+)
+ * Mirrors FeedbackWidget's responsive split so the share button always sits
+ * directly below the feedback widget on every viewport.
+ */
+export default function ShareButton({
+  variant = 'toc',
+}: {
+  variant?: 'toc' | 'inline'
+}) {
   const router = useRouter()
   const locale = router.locale || 'en-US'
   const { user, loading } = useZeaburAuth()
@@ -134,10 +145,13 @@ export default function ShareButton() {
     }
   }
 
+  const visibilityClass =
+    variant === 'inline' ? 'share-button-mobile-only' : ''
+
   return (
     <button
       type="button"
-      className={`share-button ${copied ? 'share-button-copied' : ''}`}
+      className={`share-button ${visibilityClass} ${copied ? 'share-button-copied' : ''}`}
       onClick={handleShare}
       aria-label={shareLabel}
     >

--- a/docs/components/ShareButton/index.tsx
+++ b/docs/components/ShareButton/index.tsx
@@ -1,0 +1,143 @@
+// MKT-2511 v0.1 — share button for Zeabur docs (Nextra).
+// SoT: zeabur.com/src/components/ShareButton (this is a copy with docs-flavoured tweaks).
+// Differences from SoT:
+//   - sonner not installed in docs → inline "Copied" state on the button itself (FeedbackWidget pattern).
+//   - User comes from useZeaburAuth (cookie + REST GraphQL) instead of Apollo useSession.
+//   - 5 locales (docs site doesn't ship id-ID).
+import { useState } from 'react'
+import { useRouter } from 'nextra/hooks'
+
+import { useZeaburAuth } from '../FeedbackWidget/useZeaburAuth'
+
+const DEFAULT_DISCOUNT = 5
+
+const SHARE_MESSAGES: Record<string, string> = {
+  'en-US':
+    'Purchase servers or AI Hub credits at {{url}} — enter my referral code "{{code}}" at checkout to enjoy {{discount}}% off!',
+  'zh-TW':
+    '在 {{url}} 購買伺服器或 AI Hub 額度，結帳時輸入我的推薦碼「{{code}}」，即可享受 {{discount}}% 折扣優惠～',
+  'zh-CN':
+    '在 {{url}} 购买服务器或 AI Hub 额度，结账时输入我的推荐码「{{code}}」，即可享受 {{discount}}% 折扣优惠～',
+  'ja-JP':
+    '{{url}} でサーバーや AI Hub クレジットを購入する際、チェックアウトで紹介コード「{{code}}」を入力すると {{discount}}% オフになります！',
+  'es-ES':
+    'Compra servidores o créditos de AI Hub en {{url}} — ingresa mi código de referencia "{{code}}" al pagar y obtén {{discount}}% de descuento.',
+}
+
+const SHARE_LABEL: Record<string, string> = {
+  'en-US': 'Share',
+  'zh-TW': '分享',
+  'zh-CN': '分享',
+  'ja-JP': 'シェア',
+  'es-ES': 'Compartir',
+}
+
+const COPIED_LABEL: Record<string, string> = {
+  'en-US': 'Copied',
+  'zh-TW': '已複製',
+  'zh-CN': '已复制',
+  'ja-JP': 'コピーしました',
+  'es-ES': 'Copiado',
+}
+
+export default function ShareButton() {
+  const router = useRouter()
+  const locale = router.locale || 'en-US'
+  const { user, loading } = useZeaburAuth()
+  const [copied, setCopied] = useState(false)
+
+  if (loading || !user?.referralCode) return null
+
+  const tmpl = SHARE_MESSAGES[locale] || SHARE_MESSAGES['en-US']
+  const shareLabel = SHARE_LABEL[locale] || SHARE_LABEL['en-US']
+  const copiedLabel = COPIED_LABEL[locale] || COPIED_LABEL['en-US']
+
+  const handleShare = async () => {
+    const pagePath = (router.asPath || '/').split(/[?#]/)[0]
+    const shareUrl = `https://zeabur.com${pagePath}?referralCode=${user.referralCode}`
+    const text = tmpl
+      .replace('{{url}}', shareUrl)
+      .replace('{{code}}', user.referralCode!)
+      .replace('{{discount}}', String(DEFAULT_DISCOUNT))
+
+    if (
+      typeof navigator !== 'undefined' &&
+      typeof navigator.share === 'function'
+    ) {
+      try {
+        await navigator.share({ text, url: shareUrl })
+        return
+      } catch (err) {
+        if ((err as { name?: string })?.name === 'AbortError') return
+      }
+    }
+
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // browser without clipboard or share API — silently skip
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      className={`share-button ${copied ? 'share-button-copied' : ''}`}
+      onClick={handleShare}
+      aria-label={shareLabel}
+    >
+      {copied ? (
+        <>
+          <CheckIcon />
+          <span>{copiedLabel}</span>
+        </>
+      ) : (
+        <>
+          <ShareIcon />
+          <span>{shareLabel}</span>
+        </>
+      )}
+    </button>
+  )
+}
+
+function ShareIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <circle cx="18" cy="5" r="3" />
+      <circle cx="6" cy="12" r="3" />
+      <circle cx="18" cy="19" r="3" />
+      <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+      <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+    </svg>
+  )
+}
+
+function CheckIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 20 20"
+      fill="none"
+      aria-hidden
+    >
+      <path
+        d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.7-10.3a.75.75 0 00-1.06-1.06L9 10.29 7.36 8.64a.75.75 0 00-1.06 1.06l2.25 2.25a.75.75 0 001.06 0l4.09-4.25z"
+        fill="currentColor"
+      />
+    </svg>
+  )
+}

--- a/docs/components/ShareButton/index.tsx
+++ b/docs/components/ShareButton/index.tsx
@@ -16,10 +16,13 @@ const DEFAULT_DISCOUNT = 5
 const POSTHOG_KEY = 'phc_TcgrjtKUGtTltFwWGj2Xhmuyv5ZHtrufIE8wgkLsruD'
 const POSTHOG_HOST = 'https://us.i.posthog.com'
 
+// Matches ShareButtonEventProperties in zeabur.com/src/utils/posthog.ts.
+// Single event + `surface` discriminator (navbar_menu_item_clicked precedent);
+// see the sibling PR description for the design audit.
 function captureShareButtonClicked(props: {
   user_id: string
   username?: string
-  page_path: string
+  source_url: string
   locale: string
   share_method: 'native_share' | 'clipboard'
 }) {
@@ -37,7 +40,7 @@ function captureShareButtonClicked(props: {
         username: props.username,
         is_logged_in: true,
         surface: 'docs',
-        page_path: props.page_path,
+        source_url: props.source_url,
         locale: props.locale,
         share_method: props.share_method,
         has_referral_code: true,
@@ -105,7 +108,7 @@ export default function ShareButton() {
     captureShareButtonClicked({
       user_id: user._id,
       username: user.username,
-      page_path: pagePath,
+      source_url: shareUrl.split(/[?#]/)[0],
       locale,
       share_method: willUseNativeShare ? 'native_share' : 'clipboard',
     })

--- a/docs/pages/styles.css
+++ b/docs/pages/styles.css
@@ -749,3 +749,45 @@ html.dark .feedback-close:hover {
 	font-size: 0.8125rem;
 	margin-left: 0.25rem;
 }
+
+/* ── ShareButton (MKT-2511 v0.1) ────────────────────────────────── */
+.share-button {
+	margin-top: 1.5rem;
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 0.5rem 0.875rem;
+	border: 1px solid rgba(128, 128, 128, 0.2);
+	border-radius: 8px;
+	background: transparent;
+	color: var(--zb-text-2);
+	font-size: 0.875rem;
+	font-family: inherit;
+	cursor: pointer;
+	transition: border-color 0.15s ease, background-color 0.15s ease,
+		color 0.15s ease;
+}
+
+.share-button:hover {
+	border-color: rgba(128, 128, 128, 0.4);
+	background: rgba(128, 128, 128, 0.04);
+}
+
+html.dark .share-button {
+	border-color: rgba(255, 255, 255, 0.1);
+}
+
+html.dark .share-button:hover {
+	border-color: rgba(255, 255, 255, 0.25);
+	background: rgba(255, 255, 255, 0.04);
+}
+
+.share-button-copied {
+	color: #059669;
+	border-color: rgba(5, 150, 105, 0.3);
+}
+
+html.dark .share-button-copied {
+	color: #34d399;
+	border-color: rgba(52, 211, 153, 0.3);
+}

--- a/docs/pages/styles.css
+++ b/docs/pages/styles.css
@@ -751,43 +751,75 @@ html.dark .feedback-close:hover {
 }
 
 /* ── ShareButton (MKT-2511 v0.1) ────────────────────────────────── */
+/* ghost link style — no border/background, mirrors the zeabur.com blog top share */
 .share-button {
-	margin-top: 1.5rem;
+	margin-top: 1rem;
 	display: inline-flex;
 	align-items: center;
-	gap: 0.5rem;
-	padding: 0.5rem 0.875rem;
-	border: 1px solid rgba(128, 128, 128, 0.2);
-	border-radius: 8px;
+	gap: 0.375rem;
+	padding: 0.25rem 0;
+	border: none;
 	background: transparent;
-	color: var(--zb-text-2);
-	font-size: 0.875rem;
+	color: var(--zb-text-muted);
+	font-size: 0.8125rem;
 	font-family: inherit;
 	cursor: pointer;
-	transition: border-color 0.15s ease, background-color 0.15s ease,
-		color 0.15s ease;
+	transition: color 0.15s ease;
 }
 
 .share-button:hover {
-	border-color: rgba(128, 128, 128, 0.4);
-	background: rgba(128, 128, 128, 0.04);
-}
-
-html.dark .share-button {
-	border-color: rgba(255, 255, 255, 0.1);
-}
-
-html.dark .share-button:hover {
-	border-color: rgba(255, 255, 255, 0.25);
-	background: rgba(255, 255, 255, 0.04);
+	color: var(--zb-text);
 }
 
 .share-button-copied {
 	color: #059669;
-	border-color: rgba(5, 150, 105, 0.3);
 }
 
 html.dark .share-button-copied {
 	color: #34d399;
-	border-color: rgba(52, 211, 153, 0.3);
+}
+
+/* visibility split mirrors .feedback-mobile-only: inline variant visible below xl, hidden at xl+.
+ * Declared AFTER base .share-button so the media query reliably overrides display. */
+@media (min-width: 1280px) {
+	.share-button-mobile-only {
+		display: none;
+	}
+}
+
+/* Share + Scroll-to-top inline row in the TOC sidebar (replaces Nextra's standalone backToTop).
+ * width:100% so flex can stretch across the sidebar; last child (ScrollToTopButton)
+ * pinned right via margin-left:auto so it stays right-aligned even when ShareButton is hidden. */
+.share-row {
+	margin-top: 1rem;
+	display: flex;
+	align-items: center;
+	width: 100%;
+	gap: 0.75rem;
+}
+
+.share-row .share-button {
+	margin-top: 0;
+}
+
+.share-row > :last-child {
+	margin-left: auto;
+}
+
+/* Main-slot row: ShareButton (left, mobile-only) + LastUpdated (right).
+ * Desktop: ShareButton hidden — last item (LastUpdated) absorbs the auto-margin, sitting at the right.
+ * Mobile: ShareButton visible at left, LastUpdated at right. */
+.last-updated-share-row {
+	display: flex;
+	align-items: center;
+	width: 100%;
+	gap: 0.75rem;
+}
+
+.last-updated-share-row .share-button {
+	margin-top: 0;
+}
+
+.last-updated-share-row > :last-child {
+	margin-left: auto;
 }

--- a/docs/pages/styles.css
+++ b/docs/pages/styles.css
@@ -761,22 +761,15 @@ html.dark .feedback-close:hover {
 	border: none;
 	background: transparent;
 	color: var(--zb-text-muted);
-	font-size: 0.8125rem;
+	font-size: var(--zb-fs-small);
 	font-family: inherit;
 	cursor: pointer;
 	transition: color 0.15s ease;
 }
 
-.share-button:hover {
-	color: var(--zb-text);
-}
-
+.share-button:hover,
 .share-button-copied {
-	color: #059669;
-}
-
-html.dark .share-button-copied {
-	color: #34d399;
+	color: var(--zb-text);
 }
 
 /* visibility split mirrors .feedback-mobile-only: inline variant visible below xl, hidden at xl+.

--- a/docs/pages/styles.css
+++ b/docs/pages/styles.css
@@ -767,9 +767,13 @@ html.dark .feedback-close:hover {
 	transition: color 0.15s ease;
 }
 
-.share-button:hover,
-.share-button-copied {
+.share-button:hover {
 	color: var(--zb-text);
+}
+
+.share-button-copied,
+.share-button-copied:hover {
+	color: var(--zb-purple);
 }
 
 /* visibility split mirrors .feedback-mobile-only: inline variant visible below xl, hidden at xl+.

--- a/docs/theme.config.js
+++ b/docs/theme.config.js
@@ -8,6 +8,7 @@ import WorkingInProgress from './components/WorkingInProgress'
 import CreateProject from './components/CreateProject'
 import LastUpdated from './components/LastUpdated'
 import FeedbackWidget from './components/FeedbackWidget'
+import ShareButton from './components/ShareButton'
 import LogoBlack from './public/logo_b.svg'
 import LogoWhite from './public/logo_w.svg'
 import IconBlack from './public/icon_b.svg'
@@ -65,6 +66,7 @@ const config = {
     return (
       <>
         {enhanced}
+        <ShareButton />
         <FeedbackWidget variant="inline" />
       </>
     )

--- a/docs/theme.config.js
+++ b/docs/theme.config.js
@@ -9,6 +9,7 @@ import CreateProject from './components/CreateProject'
 import LastUpdated from './components/LastUpdated'
 import FeedbackWidget from './components/FeedbackWidget'
 import ShareButton from './components/ShareButton'
+import ScrollToTopButton from './components/ScrollToTopButton'
 import LogoBlack from './public/logo_b.svg'
 import LogoWhite from './public/logo_w.svg'
 import IconBlack from './public/icon_b.svg'
@@ -55,18 +56,25 @@ const config = {
   main: ({ children }) => {
     // Nextra renders an empty `<div class="_mt-16" />` as a placeholder where
     // the gitTimestamp would go (between MDX content and prev/next pagination).
-    // Replace that slot with our <LastUpdated /> so the timestamp lands above
-    // the pagination instead of after it.
+    // Replace that slot with a row containing <LastUpdated /> (left) and
+    // <ShareButton variant="inline" /> (right, mobile-only) so they share a
+    // single line on small viewports.
     const kids = React.Children.toArray(children?.props?.children ?? children)
     const enhanced = kids.map((child) =>
       React.isValidElement(child) && child.props?.className === '_mt-16'
-        ? <LastUpdated key="last-updated" />
+        ? (
+            <div key="last-updated-share-row" className="last-updated-share-row">
+              {/* No `variant="inline"` here — main-slot share is visible on all
+                * viewports (desktop + mobile), unlike the TOC-sidebar one. */}
+              <ShareButton />
+              <LastUpdated />
+            </div>
+          )
         : child,
     )
     return (
       <>
         {enhanced}
-        <ShareButton />
         <FeedbackWidget variant="inline" />
       </>
     )
@@ -76,11 +84,19 @@ const config = {
       const { locale } = useRouter()
       return t.tocTitle[locale] || 'On This Page'
     },
-    backToTop: () => {
-      const { locale } = useRouter()
-      return t.backToTop[locale] || 'Scroll to top'
-    },
-    extraContent: () => <FeedbackWidget variant="toc" />,
+    // Nextra's built-in backToTop renders "Scroll to top" + chevron in its own
+    // row; we render an icon-only scroll button inside extraContent instead, so
+    // it sits on the same row as ShareButton. Disable the built-in to avoid dupes.
+    backToTop: false,
+    extraContent: () => (
+      <>
+        <FeedbackWidget variant="toc" />
+        <div className="share-row">
+          <ShareButton variant="toc" />
+          <ScrollToTopButton />
+        </div>
+      </>
+    ),
   },
   editLink: {
     content: () => {


### PR DESCRIPTION
Closes [MKT-2511](https://linear.app/zeabur/issue/MKT-2511) for the docs surface (sibling PR for blog/changelog/template lives in `zeabur/zeabur.com`).

Triggered by [MKT-2491](https://linear.app/zeabur/issue/MKT-2491) — KOL posts in May had zero attribution because URLs weren't shared with the author's referralCode attached. This adds the share button to every docs page.

## What

A `ShareButton` injected into `theme.config.js` `main` slot, right above `FeedbackWidget`, so it appears at the bottom of every article. Hidden when the visitor isn't logged in.

On click:

- **Desktop**: `navigator.clipboard.writeText(text)` + inline "Copied" state on the button itself (2s).
- **Mobile**: `navigator.share({ text, url })` with clipboard fallback.

Plus a one-line GraphQL extension to `useZeaburAuth` to expose `referralCode`.

## UI component inventory (per ticket Step 0)

| Source | Result |
|---|---|
| `zeabur-ui-lib` | Has Button + Toast, no ShareButton. ui-lib v0.1.0 alpha is not consumed by docs. **Skipped.** |
| `zeabur-dashboard referral/index.tsx:800` | clipboard + sonner pattern, copy-message i18n. sonner isn't installed in docs → adopted clipboard call, replaced toast with inline state. |
| `zeabur/docs/components/FeedbackWidget/` | **Direct template** for this PR — same i18n style (inline locale map), same success-state pattern (`status === 'success'` rendering a checkmark), same main-slot injection. |
| `zeabur.com/src/components/ShareButton` | **SoT** for the underlying ShareButton implementation. Copied here with Nextra-flavoured tweaks (inline state instead of sonner, useZeaburAuth instead of useSession, 5 locales). |

## Design decisions

- **Why not depend on sonner**: docs doesn't ship sonner. Adding it just for one toast would require a `<Toaster />` mount in the Nextra theme and a new prod dep. Instead, the button itself flips into a "Copied ✓" state for 2s — same UX result as a toast for this scope, zero new dep. Matches `FeedbackWidget`'s success-state pattern.
- **Why a sibling-component copy instead of npm import from zeabur.com**: cross-repo published flow for ui-lib v0.1 alpha hasn't been validated, and docs ↔ zeabur.com share no monorepo workspace. Ticket explicitly allows "copy + mark SoT" path.
- **CSS**: minimal `.share-button` / `.share-button-copied` rules in `pages/styles.css`, mirroring the `.feedback-*` neighbourhood for visual consistency.
- **Nextra share-button conventions**: spot-checked common Nextra docs sites and Nextra's official docs — there's no built-in share button and no strong community convention. Built-in `feedback` and `editLink` go in the right rail; `FeedbackWidget` already lives in `main` slot. Putting ShareButton in the same `main` slot keeps it adjacent to the page body, matching where attribution makes sense (user just finished reading → wants to share).

## i18n

5 locales hard-coded (`en-US`, `zh-TW`, `zh-CN`, `ja-JP`, `es-ES`). Docs site doesn't ship id-ID.

`{{discount}}` is hard-coded to `5%` (Tier 1 default) — see sibling PR for the same caveat.

## Test plan

- [ ] Logged in (cookie `token` set on `.zeabur.com`), visit any docs page → ShareButton appears below the article, above FeedbackWidget.
- [ ] Click on desktop → clipboard contains the docs URL with `?referralCode=`, button flips to "✓ Copied" for 2s.
- [ ] Click on mobile → native share sheet opens.
- [ ] Not logged in → ShareButton is invisible.
- [ ] Locale switcher en-US / zh-TW / zh-CN / ja-JP / es-ES → label + message text reflects the current locale.

## Skipped

- No backend changes (just one new GraphQL field selection in the existing `me` query).
- No dev-server walkthrough by me — Vercel preview on this PR is the visual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/zeabur/pr/789"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784134320&installation_id=128583772&pr_number=789&repository=zeabur%2Fzeabur&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fzeabur%2Fpull%2F789&signature=292b0f2266ed74493ddc26ac63bfbfcd6737db69272b37e016f04e9091250143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a ShareButton to the documentation layout and TOC sidebar, with localized referral messaging.
  * Shares the current page via native sharing when available, otherwise copies the referral text and shows a temporary “Copied” state.
  * Referral links appear only when a referral code is available.
  * Added a “scroll to top” button in the TOC, and adjusted the TOC header controls.
  * Sends best-effort analytics for share interactions.

* **Style**
  * Added ShareButton styling, hover/copy visuals, and responsive layout positioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->