### PR TITLE
docs: instruct users to get GraphQL schema from our API

### DIFF
--- a/docs/pages/en-US/developer.mdx
+++ b/docs/pages/en-US/developer.mdx
@@ -49,7 +49,7 @@ For connection details, authentication flow, and code examples, see [WebSocket S
 ## Tools
 
 - **[Zeabur CLI](/en-US/developer/cli)**: Log in and deploy services from your terminal with `npx zeabur`.
-- **[Apollo Explorer](https://studio.apollographql.com/public/zeabur/variant/main/explorer)**: Browse and test all GraphQL APIs online. You can also download the full Schema for IDE integration.
+- **[Apollo Explorer](https://api.zeabur.com/apollo-explorer)**: Browse and test all GraphQL APIs online. For IDE integration, fetch the full Schema under "Schema" → "SDL" (login required).
 
 ## Product-Specific APIs
 

--- a/docs/pages/en-US/developer/public-api.mdx
+++ b/docs/pages/en-US/developer/public-api.mdx
@@ -27,9 +27,9 @@ curl --request POST \
 
 ## GraphQL API
 
-You can visit our [Apollo Explorer](https://studio.apollographql.com/public/zeabur/variant/main/explorer) to view all available Zeabur API GraphQL methods, test them, and copy them as cURL commands.
+You can visit our [Apollo Explorer](https://api.zeabur.com/apollo-explorer) to view all available Zeabur API GraphQL methods, test them, and copy them as cURL commands.
 
-If you prefer writing GraphQL in an IDE or need type hints, you can download the complete Zeabur API Schema from the Explorer under "Schema" → "SDL".
+If you prefer writing GraphQL in an IDE or need type hints, you can fetch the complete Zeabur API Schema from the [Apollo Explorer](https://api.zeabur.com/apollo-explorer) under "Schema" → "SDL". Note that you need to be logged in to Zeabur to access the schema.
 
 If you find that the API you need is not in this Schema, please let us know through [Zeabur Support](https://zeabur.com/support).
 

--- a/docs/pages/en-US/developer/websocket-guide.mdx
+++ b/docs/pages/en-US/developer/websocket-guide.mdx
@@ -466,5 +466,5 @@ The authentication token accessed via `document.cookie` is stored in a non-HttpO
 - [Public API](./public-api) - Overview of all Zeabur APIs
 - [Create and Use API Keys](./api-keys) - How to generate API tokens
 - [graphql-ws Protocol](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md) - Official protocol specification
-- [Apollo Explorer](https://studio.apollographql.com/public/zeabur/variant/main/explorer) - Explore available GraphQL operations
+- [Apollo Explorer](https://api.zeabur.com/apollo-explorer) - Explore available GraphQL operations
 

--- a/docs/pages/es-ES/developer/index.mdx
+++ b/docs/pages/es-ES/developer/index.mdx
@@ -49,7 +49,7 @@ Para detalles de conexión, flujo de autenticación y ejemplos de código, consu
 ## Herramientas
 
 - **[Zeabur CLI](/es-ES/developer/cli)**: Inicia sesión y despliega servicios desde tu terminal con `npx zeabur`.
-- **[Apollo Explorer](https://studio.apollographql.com/public/zeabur/variant/main/explorer)**: Explora y prueba todas las APIs GraphQL en línea.
+- **[Apollo Explorer](https://api.zeabur.com/apollo-explorer)**: Explora y prueba todas las APIs GraphQL en línea.
 
 ## APIs Específicas de Productos
 

--- a/docs/pages/es-ES/developer/public-api.mdx
+++ b/docs/pages/es-ES/developer/public-api.mdx
@@ -27,9 +27,9 @@ curl --request POST \
 
 ## API GraphQL
 
-Puedes visitar nuestro [Explorador Apollo](https://studio.apollographql.com/public/zeabur/variant/main/explorer) para ver todos los métodos GraphQL disponibles de la API de Zeabur, probarlos y copiarlos como comandos cURL.
+Puedes visitar nuestro [Explorador Apollo](https://api.zeabur.com/apollo-explorer) para ver todos los métodos GraphQL disponibles de la API de Zeabur, probarlos y copiarlos como comandos cURL.
 
-Si prefieres escribir GraphQL en un IDE o necesitas sugerencias de tipos, puedes descargar el Esquema completo de la API de Zeabur desde el Explorador en "Schema" → "SDL".
+Si prefieres escribir GraphQL en un IDE o necesitas sugerencias de tipos, puedes obtener el Esquema completo de la API de Zeabur desde el [Explorador Apollo](https://api.zeabur.com/apollo-explorer) en "Schema" → "SDL". Ten en cuenta que necesitas haber iniciado sesión en Zeabur para acceder al Esquema.
 
 Si encuentras que la API que necesitas no está en este Esquema, por favor háganoslo saber a través de [Soporte de Zeabur](https://zeabur.com/support).
 

--- a/docs/pages/es-ES/developer/websocket-guide.mdx
+++ b/docs/pages/es-ES/developer/websocket-guide.mdx
@@ -466,5 +466,5 @@ El token de autenticación accedido a través de `document.cookie` se almacena e
 - [API Pública](./public-api) - Descripción general de todas las APIs de Zeabur
 - [Crear y Usar Claves de API](./use-api-key) - Cómo generar tokens de API
 - [Protocolo graphql-ws](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md) - Especificación oficial del protocolo
-- [Apollo Explorer](https://studio.apollographql.com/public/zeabur/variant/main/explorer) - Explorar operaciones GraphQL disponibles
+- [Apollo Explorer](https://api.zeabur.com/apollo-explorer) - Explorar operaciones GraphQL disponibles
 

--- a/docs/pages/ja-JP/developer/index.mdx
+++ b/docs/pages/ja-JP/developer/index.mdx
@@ -49,7 +49,7 @@ curl -X POST https://api.zeabur.com/graphql \
 ## ツール
 
 - **[Zeabur CLI](/ja-JP/developer/cli)**：`npx zeabur` でターミナルからログインしてサービスをデプロイ。
-- **[Apollo Explorer](https://studio.apollographql.com/public/zeabur/variant/main/explorer)**：すべての GraphQL API をオンラインで閲覧・テスト。
+- **[Apollo Explorer](https://api.zeabur.com/apollo-explorer)**：すべての GraphQL API をオンラインで閲覧・テスト。
 
 ## 製品固有の API
 

--- a/docs/pages/ja-JP/developer/public-api.mdx
+++ b/docs/pages/ja-JP/developer/public-api.mdx
@@ -27,9 +27,9 @@ curl --request POST \
 
 ## GraphQL API
 
-[Apollo Explorer](https://studio.apollographql.com/public/zeabur/variant/main/explorer) にアクセスして、利用可能なすべての Zeabur API GraphQL メソッドを確認し、テストしたり、cURL コマンドにコピーしたりすることができます。
+[Apollo Explorer](https://api.zeabur.com/apollo-explorer) にアクセスして、利用可能なすべての Zeabur API GraphQL メソッドを確認し、テストしたり、cURL コマンドにコピーしたりすることができます。
 
-IDE で GraphQL を記述することを好む場合や、型のヒントが必要な場合は、Explorer の「Schema」→「SDL」に移動して、Zeabur API の完全な Schema をダウンロードすることができます。
+IDE で GraphQL を記述することを好む場合や、型のヒントが必要な場合は、[Apollo Explorer](https://api.zeabur.com/apollo-explorer) の「Schema」→「SDL」から Zeabur API の完全な Schema を取得できます。Schema を取得するには Zeabur にログインする必要がある点にご注意ください。
 
 必要な API がこの Schema に含まれていない場合は、[Zeabur サポート](https://zeabur.com/support)でお知らせください。
 

--- a/docs/pages/ja-JP/developer/websocket-guide.mdx
+++ b/docs/pages/ja-JP/developer/websocket-guide.mdx
@@ -466,5 +466,5 @@ subscription SubscribeProjectActivity($projectID: ObjectID!) {
 - [オープン API](./public-api) - すべての Zeabur API の概要
 - [API キーの作成と使用](./use-api-key) - API トークンの生成方法
 - [graphql-ws プロトコル](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md) - 公式プロトコル仕様
-- [Apollo Explorer](https://studio.apollographql.com/public/zeabur/variant/main/explorer) - 利用可能な GraphQL 操作を探索
+- [Apollo Explorer](https://api.zeabur.com/apollo-explorer) - 利用可能な GraphQL 操作を探索
 

--- a/docs/pages/zh-CN/developer/index.mdx
+++ b/docs/pages/zh-CN/developer/index.mdx
@@ -49,7 +49,7 @@ curl -X POST https://api.zeabur.com/graphql \
 ## 工具
 
 - **[Zeabur CLI](/zh-CN/developer/cli)**：使用 `npx zeabur` 从终端登录和部署服务。
-- **[Apollo Explorer](https://studio.apollographql.com/public/zeabur/variant/main/explorer)**：在线浏览和测试所有 GraphQL API。
+- **[Apollo Explorer](https://api.zeabur.com/apollo-explorer)**：在线浏览和测试所有 GraphQL API。
 
 ## 产品特定 API
 

--- a/docs/pages/zh-CN/developer/public-api.mdx
+++ b/docs/pages/zh-CN/developer/public-api.mdx
@@ -27,9 +27,9 @@ curl --request POST \
 
 ## GraphQL API
 
-您可以访问我们的 [Apollo Explorer](https://studio.apollographql.com/public/zeabur/variant/main/explorer) 查看所有可以使用的 Zeabur API GraphQL 方法、进行测试并且复制成 cURL 命令。
+您可以访问我们的 [Apollo Explorer](https://api.zeabur.com/apollo-explorer) 查看所有可以使用的 Zeabur API GraphQL 方法、进行测试并且复制成 cURL 命令。
 
-如果您习惯在 IDE 上编写 GraphQL，或者需要获取类型提示，可以到 Explorer 中的"Schema"→"SDL"来下载 Zeabur API 的完整 Schema。
+如果您习惯在 IDE 上编写 GraphQL，或者需要获取类型提示，可以到 [Apollo Explorer](https://api.zeabur.com/apollo-explorer) 中的“Schema”→“SDL”来获取 Zeabur API 的完整 Schema。请注意，您需要登入 Zeabur 才能获取 Schema。
 
 若您发现您需要的 API 不在这个 Schema 中，请通过 [Zeabur 支持](https://zeabur.com/support) 告诉我们。
 

--- a/docs/pages/zh-CN/developer/websocket-guide.mdx
+++ b/docs/pages/zh-CN/developer/websocket-guide.mdx
@@ -466,5 +466,5 @@ subscription SubscribeProjectActivity($projectID: ObjectID!) {
 - [开放 API](./public-api) - 所有 Zeabur API 概述
 - [创建和使用 API 密钥](./use-api-key) - 如何生成 API 令牌
 - [graphql-ws 协议](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md) - 官方协议规范
-- [Apollo Explorer](https://studio.apollographql.com/public/zeabur/variant/main/explorer) - 探索可用的 GraphQL 操作
+- [Apollo Explorer](https://api.zeabur.com/apollo-explorer) - 探索可用的 GraphQL 操作
 

--- a/docs/pages/zh-TW/developer.mdx
+++ b/docs/pages/zh-TW/developer.mdx
@@ -49,7 +49,7 @@ curl -X POST https://api.zeabur.com/graphql \
 ## 工具
 
 - **[Zeabur CLI](/zh-TW/developer/cli)**：在終端以 `npx zeabur` 一行指令登入並部署服務。
-- **[Apollo Explorer](https://studio.apollographql.com/public/zeabur/variant/main/explorer)**：線上瀏覽並測試所有 GraphQL API，也可下載完整 Schema 供 IDE 使用。
+- **[Apollo Explorer](https://api.zeabur.com/apollo-explorer)**：線上瀏覽並測試所有 GraphQL API；如需 IDE 整合，可於「Schema」→「SDL」取得完整 Schema（需登入）。
 
 ## 產品專屬 API
 

--- a/docs/pages/zh-TW/developer/public-api.mdx
+++ b/docs/pages/zh-TW/developer/public-api.mdx
@@ -27,9 +27,9 @@ curl --request POST \
 
 ## GraphQL API
 
-您可以造訪我們的 [Apollo Explorer](https://studio.apollographql.com/public/zeabur/variant/main/explorer) 檢視所有可以使用的 Zeabur API GraphQL 方法、進行測試並且複製成 cURL 指令。
+您可以造訪我們的 [Apollo Explorer](https://api.zeabur.com/apollo-explorer) 檢視所有可以使用的 Zeabur API GraphQL 方法、進行測試並且複製成 cURL 指令。
 
-如果您習慣在 IDE 上編寫 GraphQL，或者需要取得類型提示，可以到 Explorer 中的「Schema」→「SDL」來下載 Zeabur API 的完整 Schema。
+如果您習慣在 IDE 上編寫 GraphQL，或者需要取得類型提示，可以到 [Apollo Explorer](https://api.zeabur.com/apollo-explorer) 中的「Schema」→「SDL」來取得 Zeabur API 的完整 Schema。請注意，您需要登入 Zeabur 才能取得 Schema。
 
 若您發現您需要的 API 不在這個 Schema 中，請透過 [Zeabur 支援](https://zeabur.com/support) 告訴我們。
 

--- a/docs/pages/zh-TW/developer/websocket-guide.mdx
+++ b/docs/pages/zh-TW/developer/websocket-guide.mdx
@@ -466,5 +466,5 @@ subscription SubscribeProjectActivity($projectID: ObjectID!) {
 - [開放 API](./public-api) - 所有 Zeabur API 概述
 - [建立和使用 API 金鑰](./api-keys) - 如何產生 API 令牌
 - [graphql-ws 協議](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md) - 官方協議規範
-- [Apollo Explorer](https://studio.apollographql.com/public/zeabur/variant/main/explorer) - 探索可用的 GraphQL 操作
+- [Apollo Explorer](https://api.zeabur.com/apollo-explorer) - 探索可用的 GraphQL 操作
 


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/zeabur/pr/792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786255825&installation_id=128583772&pr_number=792&repository=zeabur%2Fzeabur&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fzeabur%2Fpull%2F792&signature=0e502c922e84fcd84c0f8dddb77c384e2d80c88a86450192b5363c47efcb5c9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Apollo Explorer links across developer documentation and supported translations to Zeabur’s Apollo Explorer.
  - Clarified that users can browse and test GraphQL APIs through the new Explorer.
  - Added instructions for retrieving the complete schema via **Schema → SDL**; login is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->