### PR TITLE
docs: add /v1 to AI Hub endpoint table

### DIFF
--- a/docs/pages/en-US/ai-hub.mdx
+++ b/docs/pages/en-US/ai-hub.mdx
@@ -79,12 +79,12 @@ Zeabur AI Hub provides API endpoints in multiple regions:
 
 ### HND1 - Tokyo, Japan
 ```
-https://hnd1.aihub.zeabur.ai/
+https://hnd1.aihub.zeabur.ai/v1
 ```
 
 ### SFO1 - San Francisco, USA
 ```
-https://sfo1.aihub.zeabur.ai/
+https://sfo1.aihub.zeabur.ai/v1
 ```
 
 Choose the endpoint closest to your application deployment location for optimal latency.

--- a/docs/pages/zh-TW/ai-hub.mdx
+++ b/docs/pages/zh-TW/ai-hub.mdx
@@ -79,12 +79,12 @@ Zeabur AI Hub 提供多個區域的 API 端點：
 
 ### HND1 - 東京，日本
 ```
-https://hnd1.aihub.zeabur.ai/
+https://hnd1.aihub.zeabur.ai/v1
 ```
 
 ### SFO1 - 舊金山，美國
 ```
-https://sfo1.aihub.zeabur.ai/
+https://sfo1.aihub.zeabur.ai/v1
 ```
 
 選擇最接近您應用程式部署位置的端點以獲得最佳延遲表現。


### PR DESCRIPTION
## Summary
- add the required `/v1` path to HND1 and SFO1 base URLs in English and Traditional Chinese AI Hub docs
- align the endpoint table with existing SDK and curl examples

## Validation
- verified all endpoint occurrences in the edited documents include `/v1`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/zeabur/pr/793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786331708&installation_id=128583772&pr_number=793&repository=zeabur%2Fzeabur&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fzeabur%2Fpull%2F793&signature=c120e75cdd3b130c4fb4f1195d18dc0b9472043be74406b12ed30757b00b2138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated English and Traditional Chinese API endpoint examples to include the correct `/v1` versioned path for the Tokyo and San Francisco regional endpoints.
  * Improved consistency between regional endpoint documentation and the API’s versioned base URL format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->